### PR TITLE
feat: Get sd-cmd from Screwdriver API and Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # sd-cmd
 Screwdriver commands (Sharing Binaries)
+
+## Usage
+
+### Install
+```bash
+$ go get github.com/screwdriver-cd/sd-cmd
+$ cd $GOPATH/src/github.com/screwdriver-cd/sd-cmd
+$ go build -a -o sd-cmd
+```
+
+### Execute
+```bash
+$ sd_cmd exec namespace/command@version [arguments]
+```
+
+## Testing
+```bash
+go get github.com/screwdriver-cd/sd-cmd
+go test -cover github.com/screwdriver-cd/sd-cmd/...
+```
+
+## License
+Code licensed under the BSD 3-Clause license. See LICENSE file for terms.

--- a/config/config.go
+++ b/config/config.go
@@ -9,15 +9,15 @@ var (
 	SDAPIURL string
 	// SDStoreURL is SD_STORE_URL value
 	SDStoreURL string
-	// SDTokoen is SD_TOKEN value
-	SDTokoen string
+	// SDToken is SD_TOKEN value
+	SDToken string
 )
 
 // LoadConfig sets config data
 func LoadConfig() {
 	SDAPIURL = os.Getenv("SD_API_URL")
 	SDStoreURL = os.Getenv("SD_STORE_URL")
-	SDTokoen = os.Getenv("SD_TOKEN")
+	SDToken = os.Getenv("SD_TOKEN")
 	if VERSION == "" {
 		VERSION = "0.0.0"
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -9,15 +9,15 @@ var (
 	SDAPIURL string
 	// SDStoreURL is SD_STORE_URL value
 	SDStoreURL string
-	// SDAPIToken is SD_API_TOKEN value
-	SDAPIToken string
+	// SDTokoen is SD_TOKEN value
+	SDTokoen string
 )
 
 // LoadConfig sets config data
 func LoadConfig() {
 	SDAPIURL = os.Getenv("SD_API_URL")
 	SDStoreURL = os.Getenv("SD_STORE_URL")
-	SDAPIToken = os.Getenv("SD_API_TOKEN")
+	SDTokoen = os.Getenv("SD_TOKEN")
 	if VERSION == "" {
 		VERSION = "0.0.0"
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -11,11 +11,7 @@ type Executor interface {
 }
 
 // New returns each format type of Executor
-func New(args []string) (Executor, error) {
-	sdAPI, err := api.New()
-	if err != nil {
-		return nil, err
-	}
+func New(sdAPI api.API, args []string) (Executor, error) {
 	ns, cmd, ver, itr, err := util.SplitCmdWithSearch(args)
 	if err != nil {
 		return nil, err

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"github.com/screwdriver-cd/sd-cmd/screwdriver/api"
+	"github.com/screwdriver-cd/sd-cmd/util"
 )
 
 // Executor is a Executor endpoint
@@ -15,13 +16,17 @@ func New(args []string) (Executor, error) {
 	if err != nil {
 		return nil, err
 	}
-	sdCmd, err := sdAPI.GetCommand("namespace", "command", "version")
+	ns, cmd, ver, itr, err := util.SplitCmdWithSearch(args)
+	if err != nil {
+		return nil, err
+	}
+	sdCmd, err := sdAPI.GetCommand(ns, cmd, ver)
 	if err != nil {
 		return nil, err
 	}
 	switch sdCmd.Format {
 	case "binary":
-		return NewBinary(sdCmd, args[1:])
+		return NewBinary(sdCmd, args[itr+1:])
 	case "habitat":
 		return nil, nil
 	case "docker":

--- a/screwdriver/api/api.go
+++ b/screwdriver/api/api.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"strings"
 	"time"
-
-	"github.com/screwdriver-cd/sd-cmd/config"
 )
 
 const (
@@ -59,18 +57,18 @@ func (e ResponseError) Error() string {
 }
 
 // New returns API object
-func New() (API, error) {
-	c, err := newClient()
+func New(sdAPI, sdToken string) (API, error) {
+	c, err := newClient(sdAPI, sdToken)
 	if err != nil {
 		return nil, err
 	}
 	return API(c), nil
 }
 
-func newClient() (*client, error) {
+func newClient(sdAPI, sdToken string) (*client, error) {
 	c := &client{
-		baseURL: config.SDAPIURL,
-		jwt:     config.SDToken,
+		baseURL: sdAPI,
+		jwt:     sdToken,
 		client:  &http.Client{Timeout: timeoutSec * time.Second},
 	}
 	return c, nil

--- a/screwdriver/api/api.go
+++ b/screwdriver/api/api.go
@@ -70,7 +70,7 @@ func New() (API, error) {
 func newClient() (*client, error) {
 	c := &client{
 		baseURL: config.SDAPIURL,
-		jwt:     config.SDTokoen,
+		jwt:     config.SDToken,
 		client:  &http.Client{Timeout: timeoutSec * time.Second},
 	}
 	return c, nil
@@ -113,11 +113,10 @@ func (c client) GetCommand(namespace, command, version string) (*Command, error)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.jwt))
 	res, err := c.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("Faied to get command from Screwdriver API: %v", err)
+		return nil, fmt.Errorf("Failed to get command from Screwdriver API: %v", err)
 	}
 	defer res.Body.Close()
 	body, err := handleResponse(res)
-	fmt.Println(url)
 
 	if err != nil {
 		return nil, err

--- a/screwdriver/api/api.go
+++ b/screwdriver/api/api.go
@@ -106,7 +106,7 @@ func (c client) GetCommand(namespace, command, version string) (*Command, error)
 	url := fmt.Sprintf("%scommands/%s/%s", c.baseURL, namespace+"%2F"+command, version)
 	req, err := http.NewRequest("GET", url, strings.NewReader(""))
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create reqeust about command to Screwdriver API: %v", err)
+		return nil, fmt.Errorf("Failed to create request about command to Screwdriver API: %v", err)
 	}
 
 	req.Header.Set("Content-type", "application/json")

--- a/screwdriver/api/api_test.go
+++ b/screwdriver/api/api_test.go
@@ -1,1 +1,137 @@
 package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/screwdriver-cd/sd-cmd/config"
+)
+
+const (
+	fakeAPIURL   = "http://fake.com/v4/"
+	fakeAPIToken = "fake-api-token"
+	fakeJWT      = "fake-jwt"
+)
+
+func setup() {
+	config.SDAPIURL = fakeAPIURL
+	config.SDAPIToken = fakeAPIToken
+}
+
+func makeFakeHTTPClient(t *testing.T, code int, body, endpoint string) *http.Client {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(code)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, body)
+	}))
+	tr := &http.Transport{
+		Proxy: func(req *http.Request) (*url.URL, error) {
+			if endpoint == "" {
+				return url.Parse(server.URL)
+			} else if req.URL.Path == endpoint {
+				return url.Parse(server.URL)
+			}
+			return req.URL, nil
+		},
+	}
+	return &http.Client{Transport: tr}
+}
+
+func TestNew(t *testing.T) {
+	client, err := New()
+	if err != nil {
+		t.Errorf("err=%q, want nil", err)
+	}
+	if _, ok := client.(API); !ok {
+		t.Errorf("New does not fulfill API interface")
+	}
+}
+
+func TestSetJWT(t *testing.T) {
+	// success
+	c, _ := newClient()
+	c.client = makeFakeHTTPClient(t, 200, fmt.Sprintf("{\"token\": \"%v\"}", fakeJWT), "")
+	api := API(c)
+	err := api.SetJWT()
+	if err != nil {
+		t.Errorf("err=%q, want nil", err)
+	}
+	if c.jwt != fakeJWT {
+		t.Errorf("jwt=%q, want %q", c.jwt, fakeJWT)
+	}
+
+	// failure. check 4xx error message
+	err = nil
+	errMsg := "{\"statusCode\": 403,\"error\": \"Forbidden\",\"message\": \"Access Denied\"}"
+	ansMsg := "Screwdriver API 403 Forbidden: Access Denied"
+	c.client = makeFakeHTTPClient(t, 403, errMsg, "")
+	api = API(c)
+	err = api.SetJWT()
+	if err.Error() != ansMsg {
+		t.Errorf("err=%q, want %q", errMsg, ansMsg)
+	}
+
+	// failure. check some api response error
+	c, _ = newClient()
+	response := []struct {
+		code    int
+		message string
+	}{
+		{403, "{\"statusCode\": 403,\"error\": \"Forbidden\",\"message\": \"Access Denied\"}"},
+		{403, "{\"statusCode\": 403,\"error\": \"Forbidden\",\"message\": {\"This error messeg json is broken\"}"},
+		{500, "{\"statusCode\": 500,\"error\": \"InternalServerError\",\"message\": \"server error\"}"},
+		{200, "{\"statusCode\": 200,\"error\": \"JsonBroken\",{\"message\"}: \"This json is broken\"}"},
+		{600, "{\"statusCode\": 403,\"error\": \"Unknown\",\"message\": \"Unknown\"}"},
+	}
+	for _, res := range response {
+		c.client = makeFakeHTTPClient(t, res.code, res.message, "")
+		api = API(c)
+		err := api.SetJWT()
+		if err == nil {
+			t.Errorf("err=nil, want error")
+		}
+	}
+}
+
+func TestCommand(t *testing.T) {
+	// success
+	c, _ := newClient()
+	api := API(c)
+	ns, cmd, ver := "foo", "bar", "1.0"
+	jsonMsg := fmt.Sprintf("{\"namespace\":\"%s\",\"command\":\"%s\",\"version\":\"%s\",\"format\":\"binary\",\"binary\":{\"file\":\"./foobar.sh\"}}", ns, cmd, ver)
+	c.client = makeFakeHTTPClient(t, 200, jsonMsg, fmt.Sprintf("/v4/commands/%s/%s/%s", ns, cmd, ver))
+	command, err := api.GetCommand(ns, cmd, ver)
+	if err != nil {
+		t.Errorf("err=%q, want nil", err)
+	}
+	if command.Namespace != ns {
+		t.Errorf("command.Namespace=%q, want %q", command.Namespace, ns)
+	}
+
+	// failure. check some api response error
+	response := []struct {
+		code    int
+		message string
+	}{
+		{200, "{{\"namespace\":\"invalid\",\"command\":\"json\",\"version\":\"1.0\",\"format\":\"binary\",\"binary\":{\"file\":\"./foobar.sh\"}}"},
+		{403, "{\"statusCode\": 403,\"error\": \"Forbidden\",\"message\": \"Access Denied\"}"},
+	}
+	for _, res := range response {
+		c.client = makeFakeHTTPClient(t, res.code, res.message, "")
+		api = API(c)
+		_, err := api.GetCommand(ns, cmd, ver)
+		if err == nil {
+			t.Errorf("err=nil, want error")
+		}
+	}
+}
+
+func TestMain(m *testing.M) {
+	setup()
+	ret := m.Run()
+	os.Exit(ret)
+}

--- a/screwdriver/api/api_test.go
+++ b/screwdriver/api/api_test.go
@@ -7,8 +7,6 @@ import (
 	"net/url"
 	"os"
 	"testing"
-
-	"github.com/screwdriver-cd/sd-cmd/config"
 )
 
 const (
@@ -16,11 +14,6 @@ const (
 	fakeSDToken = "fake-sd-token"
 	fakeJWT     = "fake-jwt"
 )
-
-func setup() {
-	config.SDAPIURL = fakeAPIURL
-	config.SDToken = fakeSDToken
-}
 
 func makeFakeHTTPClient(t *testing.T, code int, body, endpoint string) *http.Client {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -42,7 +35,7 @@ func makeFakeHTTPClient(t *testing.T, code int, body, endpoint string) *http.Cli
 }
 
 func TestNew(t *testing.T) {
-	client, err := New()
+	client, err := New(fakeAPIURL, fakeSDToken)
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
 	}
@@ -53,7 +46,7 @@ func TestNew(t *testing.T) {
 
 func TestGetCommand(t *testing.T) {
 	// success
-	c, _ := newClient()
+	c, _ := newClient(fakeAPIURL, fakeSDToken)
 	api := API(c)
 	ns, cmd, ver := "foo", "bar", "1.0"
 	jsonMsg := fmt.Sprintf("{\"namespace\":\"%s\",\"command\":\"%s\",\"version\":\"%s\",\"format\":\"binary\",\"binary\":{\"file\":\"./foobar.sh\"}}", ns, cmd, ver)
@@ -99,7 +92,6 @@ func TestGetCommand(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	setup()
 	ret := m.Run()
 	os.Exit(ret)
 }

--- a/screwdriver/api/api_test.go
+++ b/screwdriver/api/api_test.go
@@ -19,7 +19,7 @@ const (
 
 func setup() {
 	config.SDAPIURL = fakeAPIURL
-	config.SDTokoen = fakeSDToken
+	config.SDToken = fakeSDToken
 }
 
 func makeFakeHTTPClient(t *testing.T, code int, body, endpoint string) *http.Client {

--- a/screwdriver/api/api_test.go
+++ b/screwdriver/api/api_test.go
@@ -97,7 +97,7 @@ func TestSetJWT(t *testing.T) {
 	}
 }
 
-func TestCommand(t *testing.T) {
+func TestGetCommand(t *testing.T) {
 	// success
 	c, _ := newClient()
 	api := API(c)

--- a/screwdriver/store/store.go
+++ b/screwdriver/store/store.go
@@ -114,7 +114,7 @@ func (c client) GetCommand() (*Command, error) {
 	command.Spec = c.spec
 	request, err := http.NewRequest("GET", c.baseURL, strings.NewReader(""))
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create reqeust about command to Store API: %v", err)
+		return nil, fmt.Errorf("Failed to create request about command to Store API: %v", err)
 	}
 	res, err := c.client.Do(request)
 	if err != nil {

--- a/screwdriver/store/store.go
+++ b/screwdriver/store/store.go
@@ -98,7 +98,9 @@ func handleResponse(res *http.Response) ([]byte, error) {
 	}
 }
 
-func reviseContentType(ct string) string {
+// parseContentType returns content type of Command from Store API
+// ex("text/plain; charset=UTF-8" => "text/plain")
+func parseContentType(ct string) string {
 	vers := strings.Split(ct, ";")
 	for _, str := range vers {
 		if strings.Contains(str, "/") {
@@ -125,7 +127,7 @@ func (c client) GetCommand() (*Command, error) {
 	if err != nil {
 		return nil, err
 	}
-	command.Type = reviseContentType(res.Header.Get("Content-type"))
+	command.Type = parseContentType(res.Header.Get("Content-type"))
 	command.Body = body
 	return command, nil
 }

--- a/screwdriver/store/store.go
+++ b/screwdriver/store/store.go
@@ -53,7 +53,7 @@ func commandURL(meta *api.Command) (string, error) {
 	return "", fmt.Errorf("The format is not binary")
 }
 
-// New returns API object
+// New returns Store object
 func New(meta *api.Command) (Store, error) {
 	c, err := newClient(meta)
 	if err != nil {

--- a/screwdriver/store/store.go
+++ b/screwdriver/store/store.go
@@ -1,9 +1,14 @@
 package store
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
+	"github.com/screwdriver-cd/sd-cmd/config"
 	"github.com/screwdriver-cd/sd-cmd/screwdriver/api"
 )
 
@@ -11,8 +16,8 @@ const (
 	timeoutSec = 180
 )
 
-// API is a Store API endpoint
-type API interface {
+// Store is a Store API endpoint
+type Store interface {
 	GetCommand() (*Command, error)
 }
 
@@ -35,17 +40,92 @@ type Command struct {
 	Meta *api.Command
 }
 
+func (e ResponseError) Error() string {
+	return fmt.Sprintf("Store API %d %s", e.StatusCode, e.Reason)
+}
+
+func commandURL(meta *api.Command) (string, error) {
+	if meta.Format == "binary" {
+		url := fmt.Sprintf("%scommands/%s%%2F%s/%s", config.SDStoreURL,
+			meta.Namespace, meta.Command, meta.Version)
+		return url, nil
+	}
+	return "", fmt.Errorf("The format is not binary")
+}
+
 // New returns API object
-func New(meta *api.Command) (API, error) {
+func New(meta *api.Command) (Store, error) {
+	c, err := newClient(meta)
+	if err != nil {
+		return nil, err
+	}
+	return Store(c), nil
+}
+
+func newClient(meta *api.Command) (*client, error) {
+	baseURL, err := commandURL(meta)
+	if err != nil {
+		return nil, err
+	}
 	c := &client{
-		baseURL: "http://store/base/",
+		baseURL: baseURL,
 		client:  &http.Client{Timeout: timeoutSec * time.Second},
 		meta:    meta,
 	}
-	return API(c), nil
+	return c, nil
+}
+
+func handleResponse(res *http.Response) ([]byte, error) {
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Reading response Body from Store API: %v", err)
+	}
+
+	switch res.StatusCode / 100 {
+	case 2:
+		return body, nil
+	case 4:
+		res := new(ResponseError)
+		err = json.Unmarshal(body, res)
+		if err != nil {
+			return nil, fmt.Errorf("Unparseable error response from Store API: %v", err)
+		}
+		return nil, res
+	case 5:
+		return nil, fmt.Errorf("%v: Store API has internal server error", res.StatusCode)
+	default:
+		return nil, fmt.Errorf("Unknown error happen while communicate with Store API")
+	}
+}
+
+func reviseContentType(ct string) string {
+	vers := strings.Split(ct, ";")
+	for _, str := range vers {
+		if strings.Contains(str, "/") {
+			return strings.Trim(str, " ")
+		}
+	}
+	return ""
 }
 
 // GetCommand returns Command from Store API
 func (c client) GetCommand() (*Command, error) {
-	return nil, nil
+	command := new(Command)
+	command.Meta = c.meta
+	request, err := http.NewRequest("GET", c.baseURL, strings.NewReader(""))
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create reqeust about command to Store API: %v", err)
+	}
+	res, err := c.client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("Faied to get command from Store API: %v", err)
+	}
+	defer res.Body.Close()
+	body, err := handleResponse(res)
+	if err != nil {
+		return nil, err
+	}
+	command.Type = reviseContentType(res.Header.Get("Content-type"))
+	command.Body = body
+	return command, nil
 }

--- a/screwdriver/store/store.go
+++ b/screwdriver/store/store.go
@@ -118,7 +118,7 @@ func (c client) GetCommand() (*Command, error) {
 	}
 	res, err := c.client.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("Faied to get command from Store API: %v", err)
+		return nil, fmt.Errorf("Failed to get command from Store API: %v", err)
 	}
 	defer res.Body.Close()
 	body, err := handleResponse(res)

--- a/screwdriver/store/store_test.go
+++ b/screwdriver/store/store_test.go
@@ -49,16 +49,16 @@ func makeFakeHTTPClient(t *testing.T, code int, body, endpoint, cType string) *h
 	return &http.Client{Transport: tr}
 }
 
-func dummySDCommand() (meta *api.Command) {
-	meta = &api.Command{
+func dummySDCommand() (spec *api.Command) {
+	spec = &api.Command{
 		Namespace:   dummyNameSpace,
 		Command:     dummyCommand,
 		Description: dummyDescription,
 		Version:     dummyVersion,
 		Format:      dummyFormat,
 	}
-	meta.Binary.File = dummyFile
-	return meta
+	spec.Binary.File = dummyFile
+	return spec
 }
 
 func TestNew(t *testing.T) {

--- a/screwdriver/store/store_test.go
+++ b/screwdriver/store/store_test.go
@@ -1,1 +1,138 @@
 package store
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/screwdriver-cd/sd-cmd/config"
+	"github.com/screwdriver-cd/sd-cmd/screwdriver/api"
+)
+
+const (
+	dummyNameSpace   = "foo-dummy"
+	dummyCommand     = "cmd-dummy"
+	dummyVersion     = "1.1.1"
+	dummyFormat      = "binary"
+	dummyFile        = "sd-step"
+	dummyDescription = "dummy description"
+	fakeArtifactsDir = "http://fake.store/v1/"
+	fakeAPIURL       = "http://fake.com/v4/"
+	fakeAPIToken     = "fake-api-token"
+)
+
+func setup() {
+	config.SDStoreURL = fakeArtifactsDir
+	config.SDAPIURL = fakeAPIURL
+	config.SDAPIToken = fakeAPIToken
+}
+
+func makeFakeHTTPClient(t *testing.T, code int, body, endpoint, cType string) *http.Client {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(code)
+		w.Header().Set("Content-Type", cType)
+		fmt.Fprintf(w, body)
+	}))
+	tr := &http.Transport{
+		Proxy: func(req *http.Request) (*url.URL, error) {
+			if endpoint == "" {
+				return url.Parse(server.URL)
+			} else if req.URL.Path == endpoint {
+				return url.Parse(server.URL)
+			}
+			return req.URL, nil
+		},
+	}
+	return &http.Client{Transport: tr}
+}
+
+func dummySDCommand() (meta *api.Command) {
+	meta = &api.Command{
+		Namespace:   dummyNameSpace,
+		Command:     dummyCommand,
+		Description: dummyDescription,
+		Version:     dummyVersion,
+		Format:      dummyFormat,
+	}
+	meta.Binary.File = dummyFile
+	return meta
+}
+
+func TestNew(t *testing.T) {
+	var sdCommand *api.Command
+	var store Store
+	var err error
+
+	// success
+	sdCommand = dummySDCommand()
+	store, err = New(sdCommand)
+	if err != nil {
+		t.Errorf("err=%q, want nil", err)
+	}
+	if _, ok := store.(Store); !ok {
+		t.Errorf("New does not fulfill API interface")
+	}
+
+	// failure
+	sdCommand.Format = "docker"
+	store, err = New(sdCommand)
+	if err == nil {
+		t.Errorf("err=nil, want error")
+	}
+}
+
+func TestCommand(t *testing.T) {
+	// success
+	sdCommand := dummySDCommand()
+	c, _ := newClient(sdCommand)
+	store := Store(c)
+	dummyURL := fmt.Sprintf("/v1/commands/%s/%s/%s", dummyNameSpace, dummyCommand, dummyVersion)
+	c.client = makeFakeHTTPClient(t, 200, "Hello World", dummyURL, "text/plain")
+	binary, err := store.GetCommand()
+	if err != nil {
+		t.Errorf("err=%q, want nil", err)
+	}
+	if binary.Type != "text/plain" {
+		t.Errorf("binary.Type=%q, want %q", binary.Type, "text/plain")
+	}
+	if string(binary.Body) != "Hello World" {
+		t.Errorf("binary.Body=%q, want %q", string(binary.Body), "Hello World")
+	}
+
+	// failure. check 4xx error message
+	sdCommand = dummySDCommand()
+	c, _ = newClient(sdCommand)
+	c.client = makeFakeHTTPClient(t, 404, "{\"statusCode\": 404, \"error\": \"Not Found\"}", "", "text/plain")
+	store = Store(c)
+	_, err = store.GetCommand()
+	if err.Error() != "Store API 404 Not Found" {
+		t.Errorf("err=%q, want %q", err.Error(), "Store API 404 Not Found")
+	}
+
+	// failure. check some api response error
+	sdCommand = dummySDCommand()
+	c, _ = newClient(sdCommand)
+	clients := []*http.Client{
+		makeFakeHTTPClient(t, 404, "{\"statusCode\": 404, \"error\": \"Not Found\"}", "", "text/plain"),
+		makeFakeHTTPClient(t, 500, "ERROR", "", "text/plain"),
+		makeFakeHTTPClient(t, 600, "ERROR", "", "text/plain"),
+		makeFakeHTTPClient(t, 404, "{{\"statusCode\": 404, \"error\": \"Not Found\"}", "", "text/plain"),
+	}
+	for _, client := range clients {
+		c.client = client
+		store = Store(c)
+		_, err := store.GetCommand()
+		if err == nil {
+			t.Errorf("err=nil, want error")
+		}
+	}
+}
+
+func TestMain(m *testing.M) {
+	setup()
+	ret := m.Run()
+	os.Exit(ret)
+}

--- a/screwdriver/store/store_test.go
+++ b/screwdriver/store/store_test.go
@@ -21,13 +21,13 @@ const (
 	dummyDescription = "dummy description"
 	fakeArtifactsDir = "http://fake.store/v1/"
 	fakeAPIURL       = "http://fake.com/v4/"
-	fakeAPIToken     = "fake-api-token"
+	fakeSDToken      = "fake-sd-token"
 )
 
 func setup() {
 	config.SDStoreURL = fakeArtifactsDir
 	config.SDAPIURL = fakeAPIURL
-	config.SDAPIToken = fakeAPIToken
+	config.SDTokoen = fakeSDToken
 }
 
 func makeFakeHTTPClient(t *testing.T, code int, body, endpoint, cType string) *http.Client {

--- a/screwdriver/store/store_test.go
+++ b/screwdriver/store/store_test.go
@@ -84,7 +84,7 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func TestCommand(t *testing.T) {
+func TestGetCommand(t *testing.T) {
 	// success
 	sdCommand := dummySDCommand()
 	c, _ := newClient(sdCommand)

--- a/screwdriver/store/store_test.go
+++ b/screwdriver/store/store_test.go
@@ -27,7 +27,7 @@ const (
 func setup() {
 	config.SDStoreURL = fakeArtifactsDir
 	config.SDAPIURL = fakeAPIURL
-	config.SDTokoen = fakeSDToken
+	config.SDToken = fakeSDToken
 }
 
 func makeFakeHTTPClient(t *testing.T, code int, body, endpoint, cType string) *http.Client {

--- a/sd-cmd.go
+++ b/sd-cmd.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/screwdriver-cd/sd-cmd/config"
 	"github.com/screwdriver-cd/sd-cmd/executor"
+	"github.com/screwdriver-cd/sd-cmd/screwdriver/api"
 )
 
 var cleanExit = func() {
@@ -27,10 +28,10 @@ func init() {
 	config.LoadConfig()
 }
 
-func runCommand(args []string) error {
+func runCommand(sdAPI api.API, args []string) error {
 	switch args[1] {
 	case "exec":
-		executor, err := executor.New(args[2:])
+		executor, err := executor.New(sdAPI, args[2:])
 		if err != nil {
 			return fmt.Errorf("Failed to create executor: %v", err)
 		}
@@ -58,7 +59,13 @@ func main() {
 		os.Exit(0)
 	}
 
-	err := runCommand(os.Args)
+	sdAPI, err := api.New(config.SDAPIURL, config.SDToken)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	err = runCommand(sdAPI, os.Args)
 	if err != nil {
 		fmt.Printf("error happen: %v\n", err)
 		os.Exit(0)

--- a/util/util.go
+++ b/util/util.go
@@ -5,11 +5,11 @@ import (
 	"regexp"
 )
 
-var fullCommandRegexp = regexp.MustCompile(`^([a-zA-Z0-9-_]+)\/([a-zA-Z0-9-_]+)@([a-z0-9-~\*\^\.]+)$`)
+var fullCommandRegexp = regexp.MustCompile(`^([\w-]+)\/([\w-]+)@([a-z0-9-~\*\^\.]+)$`)
 var xrangesRegexp = regexp.MustCompile(`^(?:(\d+)\.)?(?:(\d+)\.)?([\*x]|\d+)$`)
 var tildeRangesRegexp = regexp.MustCompile(`^~\d(\.\d)?(\.\d)?$`)
 var caretRangesAndPinningRegexp = regexp.MustCompile(`^(\^)?\d(\.\d){2}$`)
-var tagRegexp = regexp.MustCompile(`^[a-z0-9-]+$`)
+var tagRegexp = regexp.MustCompile(`^[a-z][a-z0-9-]+$`)
 
 func checkVersion(ver string) bool {
 	if caretRangesAndPinningRegexp.Match([]byte(ver)) {

--- a/util/util.go
+++ b/util/util.go
@@ -5,10 +5,27 @@ import (
 	"regexp"
 )
 
+// full command has <COMMAND_NAMESPACE>/<COMMAND_NAME>@<VERSION>.
+// COMMAND_NAMESPACE can only be named with A-Z,a-z,0-9,-,_
+// COMMAND_NAME can only be named with A-Z,a-z,0-9,-,_
+// VERSION can only be a-z0-9.~*^
+// ex(cmd-namespace/cmd_name@1.0.0)
 var fullCommandRegexp = regexp.MustCompile(`^([\w-]+)\/([\w-]+)@([a-z0-9-~\*\^\.]+)$`)
+
+// xrangesRegexp check VERSION of X-Ranges.
+// ex(1.2.* 1.2 1.x 1 *)
 var xrangesRegexp = regexp.MustCompile(`^(?:(\d+)\.)?(?:(\d+)\.)?([\*x]|\d+)$`)
+
+// tildeRangesRegexp check VERSION of Tilde Ranges
+// ex(~1.2.3 ~1.2 ~1)
 var tildeRangesRegexp = regexp.MustCompile(`^~\d(\.\d)?(\.\d)?$`)
+
+// caretRangesAndPinningRegexp check VERSION of Caret Ranges and Explicit Pinning
+// ex(^1.2.3 ^0.2.5 ^0.0.4 1.2.3 1.5.3)
 var caretRangesAndPinningRegexp = regexp.MustCompile(`^(\^)?\d(\.\d){2}$`)
+
+// tagRegexp check VERSION of Tags. Tags can only be named with A-Z,a-z,0-9,-
+// ex(latest stable feature-abc)
 var tagRegexp = regexp.MustCompile(`^[a-z][a-z0-9-]+$`)
 
 func checkVersion(ver string) bool {

--- a/util/util.go
+++ b/util/util.go
@@ -37,7 +37,7 @@ func SplitCmd(cmd string) (namespace, command, version string, err error) {
 	}
 
 	if len(values[0]) != 4 {
-		err = fmt.Errorf("The full command has somthing wrong")
+		err = fmt.Errorf("There is something wrong with the full command")
 		return
 	}
 

--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SplitCmd split full command to namespace, command, version.
+// ex(ns/cmd/1.0.1 => ns cmd 1.0.1)
+func SplitCmd(cmd string) (namespace, command, version string, err error) {
+	splitNamespce := strings.Split(cmd, "/")
+	if len(splitNamespce) < 2 {
+		err = fmt.Errorf("Command format is not valid")
+		return
+	}
+	splitCmdAndVer := strings.Split(splitNamespce[1], "@")
+	if len(splitCmdAndVer) < 2 {
+		err = fmt.Errorf("Command format is not valid")
+		return
+	}
+	namespace = splitNamespce[0]
+	command = splitCmdAndVer[0]
+	version = splitCmdAndVer[1]
+	return
+}
+
+// SplitCmdWithSearch search full command. If there is valid full command, return splited full command name.
+func SplitCmdWithSearch(cmds []string) (namespace, command, version string, itr int, err error) {
+	for i, val := range cmds {
+		ns, cmd, ver, err := SplitCmd(val)
+		if err == nil {
+			return ns, cmd, ver, i, err
+		}
+	}
+	return "", "", "", -1, fmt.Errorf("There is no valid command format")
+}

--- a/util/util.go
+++ b/util/util.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-// SplitCmd split full command to namespace, command, version.
+// SplitCmd splits full command to namespace, command, version.
 // ex(ns/cmd/1.0.1 => ns cmd 1.0.1)
 func SplitCmd(cmd string) (namespace, command, version string, err error) {
 	splitNamespce := strings.Split(cmd, "/")
@@ -24,7 +24,7 @@ func SplitCmd(cmd string) (namespace, command, version string, err error) {
 	return
 }
 
-// SplitCmdWithSearch search full command. If there is valid full command, return splited full command name.
+// SplitCmdWithSearch searches full command. If there is valid full command, return split full command name.
 func SplitCmdWithSearch(cmds []string) (namespace, command, version string, itr int, err error) {
 	for i, val := range cmds {
 		ns, cmd, ver, err := SplitCmd(val)

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,50 @@
+package util
+
+import "testing"
+
+func TestSplitCmd(t *testing.T) {
+	// success
+	ns, cmd, ver, err := SplitCmd("foo/bar@1.0")
+	if err != nil {
+		t.Errorf("err=%q, want nil", err)
+	}
+	if ns != "foo" || cmd != "bar" || ver != "1.0" {
+		t.Errorf("namespace=%q, command=%q, version=%q, want %q, %q, %q", ns, cmd, ver, "foo", "bar", "1.0")
+	}
+
+	// failure
+	fullCommandNames := []string{
+		"foo/bar/1.0",
+		"foo@bar/1.0",
+		"foo@bar@1.0",
+		"foobar@1.0",
+		"foo/bar1.0",
+		"forbar1.0",
+		"foo-bar@1.0",
+		"foo/bar-1.0",
+		"",
+	}
+	for _, cmdName := range fullCommandNames {
+		_, _, _, err := SplitCmd(cmdName)
+		if err == nil {
+			t.Errorf("err=nil, want error")
+		}
+	}
+}
+
+func TestSplitCmdWithSearch(t *testing.T) {
+	// success
+	ns, cmd, ver, itr, err := SplitCmdWithSearch([]string{"exec", "foo/bar@1.0", "sample"})
+	if err != nil {
+		t.Errorf("err=%q, want nil", err)
+	}
+	if ns != "foo" || cmd != "bar" || ver != "1.0" || itr != 1 {
+		t.Errorf("namespace=%q, command=%q, version=%q, want %q, %q, %q", ns, cmd, ver, "foo", "bar", "1.0")
+	}
+
+	// failure
+	_, _, _, _, err = SplitCmdWithSearch([]string{"exec", "foo-bar-1.0", "sample"})
+	if err == nil {
+		t.Errorf("err=nil, want error")
+	}
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -25,6 +25,7 @@ func TestSplitCmd(t *testing.T) {
 		{"foo/bar@latest", "foo", "bar", "latest"},
 		{"foo/bar@stable", "foo", "bar", "stable"},
 		{"foo/bar@feature-abc", "foo", "bar", "feature-abc"},
+		{"Foo/Bar@feature-abc", "Foo", "Bar", "feature-abc"},
 	}
 
 	for _, c := range fullCommands {
@@ -64,6 +65,8 @@ func TestSplitCmd(t *testing.T) {
 		"foo/bar@1.0.",
 		"foo/bar@1.0.1.0",
 		"foo/bar@aaa_bbb",
+		"foo/bar@-tag",
+		"foo/bar@Tag",
 	}
 	for _, cmdName := range fullCommandNames {
 		_, _, _, err := SplitCmd(cmdName)

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -4,12 +4,37 @@ import "testing"
 
 func TestSplitCmd(t *testing.T) {
 	// success
-	ns, cmd, ver, err := SplitCmd("foo/bar@1.0")
-	if err != nil {
-		t.Errorf("err=%q, want nil", err)
+	fullCommands := []struct {
+		fullCommand  string
+		namespaceAns string
+		commandAns   string
+		versionAns   string
+	}{
+		{"foo/bar@1.2.*", "foo", "bar", "1.2.*"},
+		{"foo/bar@1.2", "foo", "bar", "1.2"},
+		{"foo/bar@1.x", "foo", "bar", "1.x"},
+		{"foo/bar@1", "foo", "bar", "1"},
+		{"foo/bar@~1.2.3", "foo", "bar", "~1.2.3"},
+		{"foo/bar@~1.2", "foo", "bar", "~1.2"},
+		{"foo/bar@~1", "foo", "bar", "~1"},
+		{"foo/bar@^1.2.3", "foo", "bar", "^1.2.3"},
+		{"foo/bar@^0.2.5", "foo", "bar", "^0.2.5"},
+		{"foo/bar@^0.0.4", "foo", "bar", "^0.0.4"},
+		{"foo/bar@1.2.3", "foo", "bar", "1.2.3"},
+		{"foo/bar@1.5.3", "foo", "bar", "1.5.3"},
+		{"foo/bar@latest", "foo", "bar", "latest"},
+		{"foo/bar@stable", "foo", "bar", "stable"},
+		{"foo/bar@feature-abc", "foo", "bar", "feature-abc"},
 	}
-	if ns != "foo" || cmd != "bar" || ver != "1.0" {
-		t.Errorf("namespace=%q, command=%q, version=%q, want %q, %q, %q", ns, cmd, ver, "foo", "bar", "1.0")
+
+	for _, c := range fullCommands {
+		ns, cmd, ver, err := SplitCmd(c.fullCommand)
+		if err != nil {
+			t.Errorf("%q err=%q, want nil", c.fullCommand, err)
+		}
+		if ns != c.namespaceAns || cmd != c.commandAns || ver != c.versionAns {
+			t.Errorf("namespace=%q, command=%q, version=%q, want %q, %q, %q", ns, cmd, ver, c.namespaceAns, c.commandAns, c.versionAns)
+		}
 	}
 
 	// failure
@@ -27,7 +52,23 @@ func TestSplitCmd(t *testing.T) {
 	for _, cmdName := range fullCommandNames {
 		_, _, _, err := SplitCmd(cmdName)
 		if err == nil {
-			t.Errorf("err=nil, want error")
+			t.Errorf("%q err=nil, want error", cmdName)
+		}
+	}
+
+	// failure by invalid version
+	fullCommandNames = []string{
+		"foo/bar@1.0.",
+		"foo/bar@*.1.0",
+		"foo/bar@x.1.0",
+		"foo/bar@1.0.",
+		"foo/bar@1.0.1.0",
+		"foo/bar@aaa_bbb",
+	}
+	for _, cmdName := range fullCommandNames {
+		_, _, _, err := SplitCmd(cmdName)
+		if err == nil {
+			t.Errorf("%q err=nil, want error", cmdName)
 		}
 	}
 }


### PR DESCRIPTION
## Context
Can get response from Screwdriver API and Store.

To execute binary, we need to make it possible to get command information and the binary from Screwdriver API and Store, thus I implement this features.

## Objective
Execute binary command procedure is as follows

1. Get command information from Screwdriver API
2. Get the binary from Store
3. Exec the binary

In this PR is about 1 and 2 features.

There is no /v4/commands/ now, thus I created this by using mock which referenced from [command design](https://github.com/screwdriver-cd/screwdriver/blob/master/design/commands.md).

## References
[command design](https://github.com/screwdriver-cd/screwdriver/blob/master/design/commands.md)