### PR TITLE
fix: save binary command as Binary.File

### DIFF
--- a/executor/binary.go
+++ b/executor/binary.go
@@ -40,13 +40,13 @@ func (b *Binary) download() error {
 }
 
 func (b *Binary) install() (string, error) {
-	dirPath := filepath.Join(config.BaseCommandPath, b.Command.Spec.Namespace, b.Command.Spec.Name)
+	dirPath := filepath.Join(config.BaseCommandPath, b.Command.Spec.Namespace, b.Command.Spec.Name, b.Command.Spec.Version)
 
 	if err := os.MkdirAll(dirPath, 0777); err != nil {
 		return "", fmt.Errorf("Failed to create command directory: %v", err)
 	}
 
-	path := filepath.Join(dirPath, b.Command.Spec.Version)
+	path := filepath.Join(dirPath, b.Command.Spec.Binary.File)
 	file, err := os.Create(path)
 	if err != nil {
 		return "", fmt.Errorf("Failed to create command file: %v", err)

--- a/executor/binary_test.go
+++ b/executor/binary_test.go
@@ -54,9 +54,7 @@ func TestRun(t *testing.T) {
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
 	}
-	// if !strings.Contains(logBuffer.String(), "Hello World\n") {
-	// 	t.Errorf("log is %q, should include %q", logBuffer.String(), "Hello World\n")
-	// }
+
 	// check file directory
 	binPath := filepath.Join(config.BaseCommandPath, spec.Namespace, spec.Name, spec.Version, spec.Binary.File)
 	fInfo, err := os.Stat(binPath)
@@ -67,8 +65,6 @@ func TestRun(t *testing.T) {
 		t.Errorf("%q is directory, must be file", binPath)
 	}
 
-	logBuffer.Reset()
-
 	// success with arguments
 	bin, _ = NewBinary(dummyAPICommand(binaryFormat), []string{"arg1", "arg2"})
 	bin.Store = store.Store(new(dummyStore))
@@ -76,16 +72,6 @@ func TestRun(t *testing.T) {
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
 	}
-	// if !strings.Contains(logBuffer.String(), "Hello World\n") {
-	// 	t.Errorf("log is %q, should include %q", logBuffer.String(), "Hello World")
-	// }
-	// if !strings.Contains(logBuffer.String(), "arg1\n") {
-	// 	t.Errorf("log is %q, should include %q", logBuffer.String(), "arg1\n")
-	// }
-	// if !strings.Contains(logBuffer.String(), "arg2\n") {
-	// 	t.Errorf("log is %q, should include %q", logBuffer.String(), "arg2\n")
-	// }
-	logBuffer.Reset()
 
 	// failure. the command is broken
 	bin, _ = NewBinary(dummyAPICommand(binaryFormat), []string{})

--- a/executor/binary_test.go
+++ b/executor/binary_test.go
@@ -2,8 +2,11 @@ package executor
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/screwdriver-cd/sd-cmd/config"
 	"github.com/screwdriver-cd/sd-cmd/screwdriver/store"
 )
 
@@ -44,7 +47,8 @@ func TestRun(t *testing.T) {
 	logBuffer.Reset()
 
 	// success with no arguments
-	bin, _ := NewBinary(dummyAPICommand(binaryFormat), []string{})
+	spec := dummyAPICommand(binaryFormat)
+	bin, _ := NewBinary(spec, []string{})
 	bin.Store = store.Store(new(dummyStore))
 	err := bin.Run()
 	if err != nil {
@@ -53,6 +57,16 @@ func TestRun(t *testing.T) {
 	// if !strings.Contains(logBuffer.String(), "Hello World\n") {
 	// 	t.Errorf("log is %q, should include %q", logBuffer.String(), "Hello World\n")
 	// }
+	// check file directory
+	binPath := filepath.Join(config.BaseCommandPath, spec.Namespace, spec.Name, spec.Version, spec.Binary.File)
+	fInfo, err := os.Stat(binPath)
+	if os.IsNotExist(err) {
+		t.Errorf("err=%q, file should exist at %q", binPath, err)
+	}
+	if fInfo.IsDir() {
+		t.Errorf("%q is directory, must be file", binPath)
+	}
+
 	logBuffer.Reset()
 
 	// success with arguments

--- a/sd-cmd.go
+++ b/sd-cmd.go
@@ -36,7 +36,7 @@ func failureExit(err error) {
 func finalRecover() {
 	if p := recover(); p != nil {
 		fmt.Fprintln(os.Stderr, "ERROR: Something terrible has happened. Please file a ticket with this info:")
-		fmt.Fprintf(os.Stderr, "ERROR: %v\n%v\n", p, debug.Stack())
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n%v\n", p, string(debug.Stack()))
 		failureExit(nil)
 	}
 	successExit()


### PR DESCRIPTION
## Context
Follow the change of [command design](https://github.com/screwdriver-cd/screwdriver/blob/master/design/commands.md#formats),  fix sd-cmd to install binary command to `/opt/sd/commands/<namespace>/<name>/<version>/Binary.File`.

Also I fixed the panic log which output string not bytes.

I ran this command at local.
<img width="489" alt="2018-01-22 11 48 35" src="https://user-images.githubusercontent.com/4645011/35203196-738e682e-ff6a-11e7-954d-1142e7263611.png">

## Objective
Fixed the path to install binary command. Also I added the test to check the binary command path.

## References
[command design formats](https://github.com/screwdriver-cd/screwdriver/blob/master/design/commands.md#formats)