### PR TITLE
fix: add pipelineId to command struct

### DIFF
--- a/screwdriver/api/api.go
+++ b/screwdriver/api/api.go
@@ -52,6 +52,7 @@ type Command struct {
 	Binary struct {
 		File string `json:"file"`
 	} `json:"binary"`
+	PipilineId   string `json:"pipelineId"`
 }
 
 func (e ResponseError) Error() string {

--- a/screwdriver/api/api.go
+++ b/screwdriver/api/api.go
@@ -52,7 +52,7 @@ type Command struct {
 	Binary struct {
 		File string `json:"file"`
 	} `json:"binary"`
-	PipilineId   string `json:"pipelineId"`
+	PipelineId   string `json:"pipelineId"`
 }
 
 func (e ResponseError) Error() string {


### PR DESCRIPTION
## Context
In https://github.com/screwdriver-cd/data-schema/pull/199/files , `pipelineId` was added to `command`. 
To respond that, I add `pipelineId` to Command struct.

## Objective
Add `pipelineId` to Command struct.