### PR TITLE
fix: Use token to get command from store

### DIFF
--- a/executor/binary.go
+++ b/executor/binary.go
@@ -19,7 +19,7 @@ type Binary struct {
 
 // NewBinary returns Binary object
 func NewBinary(spec *api.Command, arg []string) (*Binary, error) {
-	storeapi, err := store.New(config.SDStoreURL, spec)
+	storeapi, err := store.New(config.SDStoreURL, spec, config.SDToken)
 	if err != nil {
 		return nil, err
 	}

--- a/screwdriver/api/api.go
+++ b/screwdriver/api/api.go
@@ -52,7 +52,7 @@ type Command struct {
 	Binary struct {
 		File string `json:"file"`
 	} `json:"binary"`
-	PipelineId   int `json:"pipelineId"`
+	PipelineId int `json:"pipelineId"`
 }
 
 func (e ResponseError) Error() string {

--- a/screwdriver/store/store.go
+++ b/screwdriver/store/store.go
@@ -26,6 +26,7 @@ type client struct {
 	baseURL string
 	client  *http.Client
 	spec    *api.Command
+	jwt     string
 }
 
 // ResponseError is an error response from the Store API
@@ -58,19 +59,20 @@ func (c *client) commandURL() (string, error) {
 }
 
 // New returns Store object
-func New(baseURL string, spec *api.Command) (Store, error) {
-	c, err := newClient(baseURL, spec)
+func New(baseURL string, spec *api.Command, sdToken string) (Store, error) {
+	c, err := newClient(baseURL, spec, sdToken)
 	if err != nil {
 		return nil, err
 	}
 	return Store(c), nil
 }
 
-func newClient(baseURL string, spec *api.Command) (*client, error) {
+func newClient(baseURL string, spec *api.Command, sdToken string) (*client, error) {
 	c := &client{
 		baseURL: baseURL,
 		client:  &http.Client{Timeout: timeoutSec * time.Second},
 		spec:    spec,
+		jwt:     sdToken,
 	}
 	return c, nil
 }
@@ -122,6 +124,7 @@ func (c client) GetCommand() (*Command, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create request about command to Store API: %v", err)
 	}
+	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.jwt))
 	res, err := c.client.Do(request)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get command from Store API: %v", err)

--- a/screwdriver/store/store_test.go
+++ b/screwdriver/store/store_test.go
@@ -68,7 +68,7 @@ func TestNew(t *testing.T) {
 
 	// success
 	sdCommand = dummySDCommand()
-	store, err = New(config.SDStoreURL, sdCommand)
+	store, err = New(config.SDStoreURL, sdCommand, config.SDToken)
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
 	}
@@ -81,7 +81,7 @@ func TestNew(t *testing.T) {
 func TestGetCommand(t *testing.T) {
 	// success
 	sdCommand := dummySDCommand()
-	c, _ := newClient(config.SDStoreURL, sdCommand)
+	c, _ := newClient(config.SDStoreURL, sdCommand, config.SDToken)
 	store := Store(c)
 	dummyURL := fmt.Sprintf("/v1/commands/%s/%s/%s", dummyNameSpace, dummyName, dummyVersion)
 	c.client = makeFakeHTTPClient(t, 200, "Hello World", dummyURL, "text/plain")
@@ -98,7 +98,7 @@ func TestGetCommand(t *testing.T) {
 
 	// failure. check 4xx error message
 	sdCommand = dummySDCommand()
-	c, _ = newClient(config.SDStoreURL, sdCommand)
+	c, _ = newClient(config.SDStoreURL, sdCommand, config.SDToken)
 	c.client = makeFakeHTTPClient(t, 404, "{\"statusCode\": 404, \"error\": \"Not Found\"}", "", "text/plain")
 	store = Store(c)
 	_, err = store.GetCommand()
@@ -108,7 +108,7 @@ func TestGetCommand(t *testing.T) {
 
 	// failure. check some api response error
 	sdCommand = dummySDCommand()
-	c, _ = newClient(config.SDStoreURL, sdCommand)
+	c, _ = newClient(config.SDStoreURL, sdCommand, config.SDToken)
 	clients := []*http.Client{
 		makeFakeHTTPClient(t, 404, "{\"statusCode\": 404, \"error\": \"Not Found\"}", "", "text/plain"),
 		makeFakeHTTPClient(t, 500, "ERROR", "", "text/plain"),
@@ -127,14 +127,14 @@ func TestGetCommand(t *testing.T) {
 	// failure.
 	sdCommand = dummySDCommand()
 	sdCommand.Format = "docker"
-	c, _ = newClient(config.SDStoreURL, sdCommand)
+	c, _ = newClient(config.SDStoreURL, sdCommand, config.SDToken)
 	store = Store(c)
 	_, err = store.GetCommand()
 	if err == nil {
 		t.Errorf("err=nil, want error")
 	}
 
-	c, _ = newClient(config.SDStoreURL, nil)
+	c, _ = newClient(config.SDStoreURL, nil, config.SDToken)
 	store = Store(c)
 	_, err = store.GetCommand()
 	if err == nil {


### PR DESCRIPTION
## Context
We added `auth` to `GET` commands in screwdriver-store(https://github.com/screwdriver-cd/store/pull/30). Therefore, we have to add authorization header to `GET` request to screwdriver-store.

## Objective
Pass SDToken when create new store client, and use it to get commands from screwdriver-store.

## Reference
https://github.com/screwdriver-cd/store/pull/30