### PR TITLE
fix: install path of binary file

### DIFF
--- a/executor/binary.go
+++ b/executor/binary.go
@@ -44,7 +44,8 @@ func (b *Binary) install() (string, error) {
 		return "", fmt.Errorf("Failed to create command directory: %v", err)
 	}
 
-	path := filepath.Join(dirPath, b.Command.Spec.Binary.File)
+	filename := filepath.Base(b.Command.Spec.Binary.File)
+	path := filepath.Join(dirPath, filename)
 	file, err := os.Create(path)
 	if err != nil {
 		return "", fmt.Errorf("Failed to create command file: %v", err)

--- a/executor/binary_test.go
+++ b/executor/binary_test.go
@@ -56,7 +56,7 @@ func TestRun(t *testing.T) {
 	}
 
 	// check file directory
-	binPath := filepath.Join(config.BaseCommandPath, spec.Namespace, spec.Name, spec.Version, spec.Binary.File)
+	binPath := filepath.Join(config.BaseCommandPath, spec.Namespace, spec.Name, spec.Version, dummyFileName)
 	fInfo, err := os.Stat(binPath)
 	if os.IsNotExist(err) {
 		t.Errorf("err=%q, file should exist at %q", binPath, err)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -24,7 +24,8 @@ const (
 	dummyNameSpace   = "foo-dummy"
 	dummyName        = "name-dummy"
 	dummyVersion     = "1.0.1"
-	dummyFile        = "sd-step"
+	dummyFileName    = "sd-step"
+	dummyFile        = "/dummy/" + dummyFileName
 	dummyDescription = "dummy description"
 )
 


### PR DESCRIPTION
## Context
Now if binary.file contains directory, it will fail to install binary file because sd-cmd tries to install binary to non-existent directory. 
So I fixed to install binary to exist directory.

## Objective
When install binary, just get binary file name from binary.file.