### PR TITLE
[WIP]fix: refactoring test code

### DIFF
--- a/executor/binary_test.go
+++ b/executor/binary_test.go
@@ -75,6 +75,24 @@ func TestRun(t *testing.T) {
 		t.Errorf("err=%q, want nil", err)
 	}
 
+	// success binary.file is relative path
+	spec = dummySpec(binaryFormat)
+	spec.Binary.File = "./sample/relative_path"
+	bin, _ = NewBinary(spec, []string{})
+	bin.Store = newDummyStore(binaryFormat, validShell, spec, nil)
+	err = bin.Run()
+	if err != nil {
+		t.Errorf("err=%q, want nil", err)
+	}
+	binPath = filepath.Join(config.BaseCommandPath, spec.Namespace, spec.Name, spec.Version, "relative_path")
+	fInfo, err = os.Stat(binPath)
+	if os.IsNotExist(err) {
+		t.Errorf("err=%q, file should exist at %q", binPath, err)
+	}
+	if fInfo.IsDir() {
+		t.Errorf("%q is directory, must be file", binPath)
+	}
+
 	// failure. the command is broken
 	spec = dummySpec(binaryFormat)
 	bin, _ = NewBinary(spec, []string{})

--- a/executor/binary_test.go
+++ b/executor/binary_test.go
@@ -12,25 +12,22 @@ import (
 )
 
 type dummyStore struct {
-	cmdType string
-	body    []byte
-	spec    *util.CommandSpec
-	err     error
+	body []byte
+	spec *util.CommandSpec
+	err  error
 }
 
-func newDummyStore(cmdType string, body string, spec *util.CommandSpec, err error) store.Store {
+func newDummyStore(body string, spec *util.CommandSpec, err error) store.Store {
 	ds := &dummyStore{
-		cmdType: cmdType,
-		body:    []byte(body),
-		spec:    spec,
-		err:     err,
+		body: []byte(body),
+		spec: spec,
+		err:  err,
 	}
 	return store.Store(ds)
 }
 
 func (d *dummyStore) GetCommand() (*store.Command, error) {
 	storeCmd := &store.Command{
-		Type: d.cmdType,
 		Body: d.body,
 		Spec: d.spec,
 	}
@@ -50,7 +47,7 @@ func TestRun(t *testing.T) {
 	// success with no arguments
 	spec := dummySpec(binaryFormat)
 	bin, _ := NewBinary(spec, []string{})
-	bin.Store = newDummyStore(binaryFormat, validShell, spec, nil)
+	bin.Store = newDummyStore(validShell, spec, nil)
 	err := bin.Run()
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
@@ -69,7 +66,7 @@ func TestRun(t *testing.T) {
 	// success with arguments
 	spec = dummySpec(binaryFormat)
 	bin, _ = NewBinary(spec, []string{"arg1", "arg2"})
-	bin.Store = newDummyStore(binaryFormat, validShell, spec, nil)
+	bin.Store = newDummyStore(validShell, spec, nil)
 	err = bin.Run()
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
@@ -79,7 +76,7 @@ func TestRun(t *testing.T) {
 	spec = dummySpec(binaryFormat)
 	spec.Binary.File = "./sample/relative_path"
 	bin, _ = NewBinary(spec, []string{})
-	bin.Store = newDummyStore(binaryFormat, validShell, spec, nil)
+	bin.Store = newDummyStore(validShell, spec, nil)
 	err = bin.Run()
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
@@ -96,7 +93,7 @@ func TestRun(t *testing.T) {
 	// failure. the command is broken
 	spec = dummySpec(binaryFormat)
 	bin, _ = NewBinary(spec, []string{})
-	bin.Store = newDummyStore(binaryFormat, invalidShell, spec, nil)
+	bin.Store = newDummyStore(invalidShell, spec, nil)
 	err = bin.Run()
 	if err == nil {
 		t.Errorf("err=nil, want error")
@@ -105,7 +102,7 @@ func TestRun(t *testing.T) {
 	// failure. the store api return error
 	spec = dummySpec(binaryFormat)
 	bin, _ = NewBinary(spec, []string{})
-	bin.Store = newDummyStore(binaryFormat, validShell, spec, fmt.Errorf("store cause error"))
+	bin.Store = newDummyStore(validShell, spec, fmt.Errorf("store cause error"))
 	err = bin.Run()
 	if err == nil {
 		t.Errorf("err=nil, want error")

--- a/executor/binary_test.go
+++ b/executor/binary_test.go
@@ -38,7 +38,7 @@ func (d *dummyStore) GetCommand() (*store.Command, error) {
 }
 
 func TestNewBinary(t *testing.T) {
-	_, err := NewBinary(dummyAPICommand(binaryFormat), []string{"arg1", "arg2"})
+	_, err := NewBinary(dummySpec(binaryFormat), []string{"arg1", "arg2"})
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
 	}
@@ -48,16 +48,16 @@ func TestRun(t *testing.T) {
 	logBuffer.Reset()
 
 	// success with no arguments
-	spec := dummyAPICommand(binaryFormat)
+	spec := dummySpec(binaryFormat)
 	bin, _ := NewBinary(spec, []string{})
-	bin.Store = newDummyStore("binary", validShell, spec, nil)
+	bin.Store = newDummyStore(binaryFormat, validShell, spec, nil)
 	err := bin.Run()
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
 	}
 
 	// check file directory
-	binPath := filepath.Join(config.BaseCommandPath, spec.Namespace, spec.Name, spec.Version, dummyFileName)
+	binPath := filepath.Join(config.BaseCommandPath, spec.Namespace, spec.Name, spec.Version, dummyBinaryFileName)
 	fInfo, err := os.Stat(binPath)
 	if os.IsNotExist(err) {
 		t.Errorf("err=%q, file should exist at %q", binPath, err)
@@ -67,27 +67,27 @@ func TestRun(t *testing.T) {
 	}
 
 	// success with arguments
-	spec = dummyAPICommand(binaryFormat)
+	spec = dummySpec(binaryFormat)
 	bin, _ = NewBinary(spec, []string{"arg1", "arg2"})
-	bin.Store = newDummyStore("binary", validShell, spec, nil)
+	bin.Store = newDummyStore(binaryFormat, validShell, spec, nil)
 	err = bin.Run()
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
 	}
 
 	// failure. the command is broken
-	spec = dummyAPICommand(binaryFormat)
+	spec = dummySpec(binaryFormat)
 	bin, _ = NewBinary(spec, []string{})
-	bin.Store = newDummyStore("binary", invalidShell, spec, nil)
+	bin.Store = newDummyStore(binaryFormat, invalidShell, spec, nil)
 	err = bin.Run()
 	if err == nil {
 		t.Errorf("err=nil, want error")
 	}
 
 	// failure. the store api return error
-	spec = dummyAPICommand(binaryFormat)
+	spec = dummySpec(binaryFormat)
 	bin, _ = NewBinary(spec, []string{})
-	bin.Store = newDummyStore("binary", validShell, spec, fmt.Errorf("store cause error"))
+	bin.Store = newDummyStore(binaryFormat, validShell, spec, fmt.Errorf("store cause error"))
 	err = bin.Run()
 	if err == nil {
 		t.Errorf("err=nil, want error")

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -51,11 +51,11 @@ func New(sdAPI api.API, args []string) (Executor, error) {
 	case "binary":
 		return NewBinary(spec, args[pos+1:])
 	case "habitat":
-		return nil, nil
+		return nil, fmt.Errorf("habitat executor is not implemented yet")
 	case "docker":
-		return nil, nil
+		return nil, fmt.Errorf("docker executor is not implemented yet")
 	}
-	return nil, nil
+	return nil, fmt.Errorf("Unknowen type")
 }
 
 func execCommand(path string, args []string) error {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -77,9 +77,8 @@ func teardown() {
 }
 
 type dummySDAPI struct {
-	cmdType string
-	spec    *util.CommandSpec
-	err     error
+	spec *util.CommandSpec
+	err  error
 }
 
 func (d *dummySDAPI) GetCommand(smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
@@ -90,11 +89,10 @@ func (d *dummySDAPI) PostCommand(specPath string, smallSpec *util.CommandSpec) (
 	return nil, nil
 }
 
-func newDummySDAPI(cmdType string, spec *util.CommandSpec, err error) api.API {
+func newDummySDAPI(spec *util.CommandSpec, err error) api.API {
 	d := &dummySDAPI{
-		cmdType: cmdType,
-		spec:    spec,
-		err:     err,
+		spec: spec,
+		err:  err,
 	}
 	return api.API(d)
 }
@@ -127,7 +125,7 @@ func dummySpec(format string) (cmd *util.CommandSpec) {
 func TestNew(t *testing.T) {
 	// success
 	spec := dummySpec(binaryFormat)
-	sdapi := newDummySDAPI(binaryFormat, spec, nil)
+	sdapi := newDummySDAPI(spec, nil)
 	executor, err := New(sdapi, []string{"ns/cmd@ver"})
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
@@ -138,7 +136,7 @@ func TestNew(t *testing.T) {
 
 	// success binary mode
 	spec = dummySpec(binaryFormat)
-	sdapi = newDummySDAPI(binaryFormat, spec, nil)
+	sdapi = newDummySDAPI(spec, nil)
 	_, err = New(sdapi, []string{"exec", "ns/cmd@ver"})
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
@@ -146,7 +144,7 @@ func TestNew(t *testing.T) {
 
 	// failure. no command
 	spec = dummySpec(binaryFormat)
-	sdapi = newDummySDAPI(binaryFormat, spec, nil)
+	sdapi = newDummySDAPI(spec, nil)
 	_, err = New(sdapi, []string{})
 	if err == nil {
 		t.Errorf("err=nil, want error")
@@ -154,7 +152,7 @@ func TestNew(t *testing.T) {
 
 	// failure. invalid command
 	spec = dummySpec(binaryFormat)
-	sdapi = newDummySDAPI(binaryFormat, spec, nil)
+	sdapi = newDummySDAPI(spec, nil)
 	_, err = New(sdapi, []string{"sd-cmd", "ns@cmd/ver"})
 	if err == nil {
 		t.Errorf("err=nil, want error")
@@ -162,7 +160,7 @@ func TestNew(t *testing.T) {
 
 	// failure. Screwdriver API error
 	spec = dummySpec(binaryFormat)
-	sdapi = newDummySDAPI(binaryFormat, spec, fmt.Errorf("Something error happen"))
+	sdapi = newDummySDAPI(spec, fmt.Errorf("Something error happen"))
 	_, err = New(sdapi, []string{"sd-cmd", "ns/cmd@ver"})
 	if err == nil {
 		t.Errorf("err=nil, want error")
@@ -170,7 +168,7 @@ func TestNew(t *testing.T) {
 
 	// failure. habitat type(not implemented yet)
 	spec = dummySpec(habitatFormat)
-	sdapi = newDummySDAPI(habitatFormat, spec, nil)
+	sdapi = newDummySDAPI(spec, nil)
 	_, err = New(sdapi, []string{"sd-cmd", "ns/cmd@ver"})
 	if err == nil {
 		t.Errorf("err=nil, want error")
@@ -178,7 +176,7 @@ func TestNew(t *testing.T) {
 
 	// failure. docker type(not implemented yet)
 	spec = dummySpec(dockerFormat)
-	sdapi = newDummySDAPI(dockerFormat, spec, nil)
+	sdapi = newDummySDAPI(spec, nil)
 	_, err = New(sdapi, []string{"sd-cmd", "ns/cmd@ver"})
 	if err == nil {
 		t.Errorf("err=nil, want error")
@@ -186,7 +184,7 @@ func TestNew(t *testing.T) {
 
 	// failure. Unknown type
 	spec = dummySpec("Unknown")
-	sdapi = newDummySDAPI("Unknown", spec, nil)
+	sdapi = newDummySDAPI(spec, nil)
 	_, err = New(sdapi, []string{"sd-cmd", "ns/cmd@ver"})
 	if err == nil {
 		t.Errorf("err=nil, want error")

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -99,8 +99,11 @@ func dummyAPICommand(format string) (cmd *util.CommandSpec) {
 		Version:     dummyVersion,
 		Format:      format,
 	}
-	cmd.Binary = new(util.Binary)
-	cmd.Binary.File = dummyFile
+	switch format {
+	case "binary":
+		cmd.Binary = new(util.Binary)
+		cmd.Binary.File = dummyFile
+	}
 	return cmd
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -21,12 +21,17 @@ const (
 )
 
 const (
-	dummyNameSpace   = "foo-dummy"
-	dummyName        = "name-dummy"
-	dummyVersion     = "1.0.1"
-	dummyFileName    = "sd-step"
-	dummyFile        = "/dummy/" + dummyFileName
-	dummyDescription = "dummy description"
+	dummyNameSpace      = "foo-dummy"
+	dummyName           = "name-dummy"
+	dummyVersion        = "1.0.1"
+	dummyDescription    = "dummy description"
+	dummyBinaryFileName = "sd-step"
+	dummyBinaryFile     = "/dummy/" + dummyBinaryFileName
+	dummyDockerImage    = "chefdk:1.2.3"
+	dummyDockerCmd      = "knife"
+	dummyHabitatMode    = "remote"
+	dummyHabitatPkg     = "core/git/2.14.1"
+	dummyHabitatCmd     = "git"
 )
 
 var (
@@ -71,27 +76,30 @@ func teardown() {
 	os.RemoveAll(config.SDArtifactsDir)
 }
 
-type dummySDAPIBinary struct{}
-
-func (d *dummySDAPIBinary) GetCommand(smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
-	return dummyAPICommand(binaryFormat), nil
+type dummySDAPI struct {
+	cmdType string
+	spec    *util.CommandSpec
+	err     error
 }
 
-func (d *dummySDAPIBinary) PostCommand(specPath string, smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
+func (d *dummySDAPI) GetCommand(smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
+	return d.spec, d.err
+}
+
+func (d *dummySDAPI) PostCommand(specPath string, smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
 	return nil, nil
 }
 
-type dummySDAPIBroken struct{}
-
-func (d *dummySDAPIBroken) GetCommand(smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
-	return nil, fmt.Errorf("Something error happen")
+func newDummySDAPI(cmdType string, spec *util.CommandSpec, err error) api.API {
+	d := &dummySDAPI{
+		cmdType: cmdType,
+		spec:    spec,
+		err:     err,
+	}
+	return api.API(d)
 }
 
-func (d *dummySDAPIBroken) PostCommand(specPath string, smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
-	return nil, fmt.Errorf("Something error happen")
-}
-
-func dummyAPICommand(format string) (cmd *util.CommandSpec) {
+func dummySpec(format string) (cmd *util.CommandSpec) {
 	cmd = &util.CommandSpec{
 		Namespace:   dummyNameSpace,
 		Name:        dummyName,
@@ -100,16 +108,26 @@ func dummyAPICommand(format string) (cmd *util.CommandSpec) {
 		Format:      format,
 	}
 	switch format {
-	case "binary":
+	case binaryFormat:
 		cmd.Binary = new(util.Binary)
-		cmd.Binary.File = dummyFile
+		cmd.Binary.File = dummyBinaryFile
+	case dockerFormat:
+		cmd.Docker = new(util.Docker)
+		cmd.Docker.Command = dummyDockerCmd
+		cmd.Docker.Image = dummyDockerImage
+	case habitatFormat:
+		cmd.Habitat = new(util.Habitat)
+		cmd.Habitat.Command = dummyHabitatCmd
+		cmd.Habitat.Mode = dummyHabitatMode
+		cmd.Habitat.Package = dummyHabitatPkg
 	}
 	return cmd
 }
 
 func TestNew(t *testing.T) {
 	// success
-	sdapi := api.API(new(dummySDAPIBinary))
+	spec := dummySpec(binaryFormat)
+	sdapi := newDummySDAPI(binaryFormat, spec, nil)
 	executor, err := New(sdapi, []string{"ns/cmd@ver"})
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
@@ -118,29 +136,33 @@ func TestNew(t *testing.T) {
 		t.Errorf("New does not fulfill API interface")
 	}
 
-	// success
-	sdapi = api.API(new(dummySDAPIBinary))
+	// success binary mode
+	spec = dummySpec(binaryFormat)
+	sdapi = newDummySDAPI(binaryFormat, spec, nil)
 	_, err = New(sdapi, []string{"exec", "ns/cmd@ver"})
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
 	}
 
 	// failure. no command
-	sdapi = api.API(new(dummySDAPIBinary))
+	spec = dummySpec(binaryFormat)
+	sdapi = newDummySDAPI(binaryFormat, spec, nil)
 	_, err = New(sdapi, []string{})
 	if err == nil {
 		t.Errorf("err=nil, want error")
 	}
 
 	// failure. invalid command
-	sdapi = api.API(new(dummySDAPIBinary))
+	spec = dummySpec(binaryFormat)
+	sdapi = newDummySDAPI(binaryFormat, spec, nil)
 	_, err = New(sdapi, []string{"sd-cmd", "ns@cmd/ver"})
 	if err == nil {
 		t.Errorf("err=nil, want error")
 	}
 
 	// failure. Screwdriver API error
-	sdapi = api.API(new(dummySDAPIBroken))
+	spec = dummySpec(binaryFormat)
+	sdapi = newDummySDAPI(binaryFormat, spec, fmt.Errorf("Something error happen"))
 	_, err = New(sdapi, []string{"sd-cmd", "ns/cmd@ver"})
 	if err == nil {
 		t.Errorf("err=nil, want error")

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -167,6 +167,30 @@ func TestNew(t *testing.T) {
 	if err == nil {
 		t.Errorf("err=nil, want error")
 	}
+
+	// failure. habitat type(not implemented yet)
+	spec = dummySpec(habitatFormat)
+	sdapi = newDummySDAPI(habitatFormat, spec, nil)
+	_, err = New(sdapi, []string{"sd-cmd", "ns/cmd@ver"})
+	if err == nil {
+		t.Errorf("err=nil, want error")
+	}
+
+	// failure. docker type(not implemented yet)
+	spec = dummySpec(dockerFormat)
+	sdapi = newDummySDAPI(dockerFormat, spec, nil)
+	_, err = New(sdapi, []string{"sd-cmd", "ns/cmd@ver"})
+	if err == nil {
+		t.Errorf("err=nil, want error")
+	}
+
+	// failure. Unknown type
+	spec = dummySpec("Unknown")
+	sdapi = newDummySDAPI("Unknown", spec, nil)
+	_, err = New(sdapi, []string{"sd-cmd", "ns/cmd@ver"})
+	if err == nil {
+		t.Errorf("err=nil, want error")
+	}
 }
 
 func TestMain(m *testing.M) {

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -1,6 +1,7 @@
 package publisher
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/screwdriver-cd/sd-cmd/screwdriver/api"
@@ -10,14 +11,52 @@ import (
 type dummySDAPIBinary struct{}
 
 const (
-	dummyNameSpace   = "foo-dummy"
-	dummyName        = "name-dummy"
-	dummyVersion     = "1.0.1"
-	dummyFile        = "sd-step"
-	dummyDescription = "dummy description"
+	binaryFormat  = "binary"
+	dockerFormat  = "docker"
+	habitatFormat = "habitat"
 )
 
-func dummyAPICommand(format string) (cmd *util.CommandSpec) {
+const (
+	dummyNameSpace      = "foo-dummy"
+	dummyName           = "name-dummy"
+	dummyVersion        = "1.0.1"
+	dummyDescription    = "dummy description"
+	dummyBinaryFileName = "sd-step"
+	dummyBinaryFile     = "/dummy/" + dummyBinaryFileName
+	dummyDockerImage    = "chefdk:1.2.3"
+	dummyDockerCmd      = "knife"
+	dummyHabitatMode    = "remote"
+	dummyHabitatPkg     = "core/git/2.14.1"
+	dummyHabitatCmd     = "git"
+)
+
+var (
+	validSpecYamlPath   = "../testdata/yaml/binary-sd-command.yaml"
+	invalidSpecYamlPath = "../testdata/yaml/invalid_sd-command.yaml"
+)
+
+type dummySDAPI struct {
+	spec *util.CommandSpec
+	err  error
+}
+
+func (d *dummySDAPI) GetCommand(smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
+	return d.spec, d.err
+}
+
+func (d *dummySDAPI) PostCommand(specPath string, smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
+	return d.spec, d.err
+}
+
+func newDummySDAPI(spec *util.CommandSpec, err error) api.API {
+	d := &dummySDAPI{
+		spec: spec,
+		err:  err,
+	}
+	return api.API(d)
+}
+
+func dummySpec(format string) (cmd *util.CommandSpec) {
 	cmd = &util.CommandSpec{
 		Namespace:   dummyNameSpace,
 		Name:        dummyName,
@@ -25,38 +64,67 @@ func dummyAPICommand(format string) (cmd *util.CommandSpec) {
 		Version:     dummyVersion,
 		Format:      format,
 	}
-	cmd.Binary = new(util.Binary)
-	cmd.Binary.File = dummyFile
+	switch format {
+	case binaryFormat:
+		cmd.Binary = new(util.Binary)
+		cmd.Binary.File = dummyBinaryFile
+	case dockerFormat:
+		cmd.Docker = new(util.Docker)
+		cmd.Docker.Command = dummyDockerCmd
+		cmd.Docker.Image = dummyDockerImage
+	case habitatFormat:
+		cmd.Habitat = new(util.Habitat)
+		cmd.Habitat.Command = dummyHabitatCmd
+		cmd.Habitat.Mode = dummyHabitatMode
+		cmd.Habitat.Package = dummyHabitatPkg
+	}
 	return cmd
-}
-
-func (d *dummySDAPIBinary) GetCommand(smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
-	return dummyAPICommand("binary"), nil
-}
-
-func (d *dummySDAPIBinary) PostCommand(specPath string, smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
-	return dummyAPICommand("binary"), nil
 }
 
 func TestNew(t *testing.T) {
 	// success
-	testDataPath := "../testdata/yaml/sd-command.yaml"
-	sdapi := api.API(new(dummySDAPIBinary))
-	_, err := New(sdapi, []string{"-f", testDataPath})
+	spec := dummySpec(binaryFormat)
+	sdapi := newDummySDAPI(spec, nil)
+	_, err := New(sdapi, []string{"-f", validSpecYamlPath})
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
+	}
+
+	// failure. invalid flag
+	spec = dummySpec(binaryFormat)
+	sdapi = newDummySDAPI(spec, nil)
+	_, err = New(sdapi, []string{"-x", "invalid_flag"})
+	if err == nil {
+		t.Errorf("err=nil, want error")
+	}
+
+	// failure. invalid yaml file
+	spec = dummySpec(binaryFormat)
+	sdapi = newDummySDAPI(spec, nil)
+	_, err = New(sdapi, []string{"-f", invalidSpecYamlPath})
+	if err == nil {
+		t.Errorf("err=nil, want error")
 	}
 }
 
 func TestRun(t *testing.T) {
-	testDataPath := "../testdata/yaml/sd-command.yaml"
-	sdapi := api.API(new(dummySDAPIBinary))
-	pub, err := New(sdapi, []string{"-f", testDataPath})
+	spec := dummySpec(binaryFormat)
+	sdapi := newDummySDAPI(spec, nil)
+	pub, err := New(sdapi, []string{"-f", validSpecYamlPath})
 	if err != nil {
 		t.Errorf("err=%v, want nil", err)
 	}
 	err = pub.Run()
 	if err != nil {
 		t.Errorf("err=%v, want nil", err)
+	}
+
+	// failure. failed to post command
+	spec = dummySpec(binaryFormat)
+	sdapi = newDummySDAPI(spec, fmt.Errorf("failed to post command"))
+	pub, _ = New(sdapi, []string{"-f", validSpecYamlPath})
+	err = pub.Run()
+	if err == nil {
+		t.Errorf("err=nil, want error")
 	}
 }

--- a/testdata/yaml/binary-sd-command.yaml
+++ b/testdata/yaml/binary-sd-command.yaml
@@ -1,0 +1,18 @@
+## Namespace for the command
+namespace: foo
+# Command name itself
+name: bar
+# Description of the command and what it does
+description: |
+  Lorem ipsum dolor sit amet.
+# Maintainer of the command
+maintainer: foo@bar.com
+# Major and Minor version number (patch is automatic)
+version: 1.0
+# Format the command is in (see below for examples)
+# Valid options: habitat, docker, binary
+format: binary
+# Binary specific config
+# if format: binary
+binary:
+    file: ./testdata/binary/hello

--- a/testdata/yaml/habitat-sd-command.yaml
+++ b/testdata/yaml/habitat-sd-command.yaml
@@ -1,0 +1,23 @@
+## Namespace for the command
+namespace: foo
+# Command name itself
+name: bar
+# Description of the command and what it does
+description: |
+  Lorem ipsum dolor sit amet.
+# Maintainer of the command
+maintainer: foo@bar.com
+# Major and Minor version number (patch is automatic)
+version: 1.0
+# Format the command is in (see below for examples)
+# Valid options: habitat, docker, binary
+format: habitat
+# Habitat specific config
+# if format: habitat
+habitat:
+    mode: remote
+    package: core/git/2.14.1
+    # If local
+    # mode: local
+    # package: ./foobar.hart
+    command: git

--- a/testdata/yaml/invalid_sd-command.yaml
+++ b/testdata/yaml/invalid_sd-command.yaml
@@ -1,0 +1,20 @@
+# INVALID YAML FILE
+
+## Namespace for the command
+ namespace: foo
+# Command name itself
+name: bar
+# Description of the command and what it does
+ description: |
+  Lorem ipsum dolor sit amet.
+# Maintainer of the command
+maintainer: foo@bar.com
+# Major and Minor version number (patch is automatic)
+version: 1.0
+# Format the command is in (see below for examples)
+# Valid options: habitat, docker, binary
+format: binary
+# Binary specific config
+# if format: binary
+binary:
+    file: ./testdata/binary/hello

--- a/util/file_loader_test.go
+++ b/util/file_loader_test.go
@@ -4,7 +4,10 @@ import (
 	"testing"
 )
 
-var commandSpecYamlPath = "../testdata/yaml/sd-command.yaml"
+const (
+	commandSpecYamlPath        = "../testdata/yaml/sd-command.yaml"
+	invalidCommandSpecYamlPath = "../testdata/yaml/invalid_sd-command.yaml"
+)
 
 func TestLoadFile(t *testing.T) {
 	LoadByte(commandSpecYamlPath)
@@ -46,5 +49,17 @@ func TestLoadYaml(t *testing.T) {
 	expect = "./testdata/binary/hello"
 	if actual.Binary.File != expect {
 		t.Errorf("got %q\nwant %q", actual.Binary.File, expect)
+	}
+
+	// failure. no yaml path
+	actual, err := LoadYaml("./there/is/no/such/path")
+	if err == nil {
+		t.Errorf("err=nil, want error")
+	}
+
+	// failure. invalid yaml
+	actual, err = LoadYaml(invalidCommandSpecYamlPath)
+	if err == nil {
+		t.Errorf("err=nil, want error")
 	}
 }


### PR DESCRIPTION
## Context
Now it looks hard to write test when we implements habitat format and docker format. I did code refactoring for sd-cmd's test and make it easy to create new tests.

Also I added some tests for code which have no tests.

- before add tests
```
% go test ./... -cover                                                                                                            (git)-[master]
?       github.com/screwdriver-cd/sd-cmd        [no test files]
ok      github.com/screwdriver-cd/sd-cmd/config 0.034s  coverage: 100.0% of statements
ok      github.com/screwdriver-cd/sd-cmd/executor       0.711s  coverage: 84.3% of statements
ok      github.com/screwdriver-cd/sd-cmd/logger 0.058s  coverage: 66.7% of statements
ok      github.com/screwdriver-cd/sd-cmd/publisher      1.013s  coverage: 80.0% of statements
ok      github.com/screwdriver-cd/sd-cmd/screwdriver/api        1.010s  coverage: 74.1% of statements
ok      github.com/screwdriver-cd/sd-cmd/screwdriver/store      0.063s  coverage: 89.4% of statements
ok      github.com/screwdriver-cd/sd-cmd/util   1.120s  coverage: 87.5% of statements
```

- after add tests
```
% go test ./... -cover                                                                                                       (git)-[refact_test]
?       github.com/screwdriver-cd/sd-cmd        [no test files]
ok      github.com/screwdriver-cd/sd-cmd/config 0.284s  coverage: 100.0% of statements
ok      github.com/screwdriver-cd/sd-cmd/executor       0.856s  coverage: 88.6% of statements
ok      github.com/screwdriver-cd/sd-cmd/logger 0.734s  coverage: 66.7% of statements
ok      github.com/screwdriver-cd/sd-cmd/publisher      0.841s  coverage: 100.0% of statements
ok      github.com/screwdriver-cd/sd-cmd/screwdriver/api        0.835s  coverage: 84.3% of statements
ok      github.com/screwdriver-cd/sd-cmd/screwdriver/store      1.392s  coverage: 89.4% of statements
ok      github.com/screwdriver-cd/sd-cmd/util   0.944s  coverage: 95.0% of statements
```

## Objective
Fixed each packages test, and code a little bit.
The behavior of sd-cmd are almost unchanged.

Almost every packages need util.CommandSpec and I wrote code which create the structure on each packages tests.
If you know the good way to decrease this duplicate function, please tell me.

Also If you have some opinion about tests, please write comments 🙏 


