### PR TITLE
fix: make base path for cmds configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,4 +28,7 @@ func LoadConfig() {
 	if VERSION == "" {
 		VERSION = "0.0.0"
 	}
+	if len(os.Getenv("SD_BASE_COMMAND_PATH")) != 0 {
+		BaseCommandPath = os.Getenv("SD_BASE_COMMAND_PATH")
+	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,6 +14,7 @@ const (
 	dummyToken          = "dummy-token"
 	dummyStoreURL       = "dummy-store/"
 	dummySDArtifactsDir = "dummy/sd/Artifacts/"
+	dummyCustomCmdPath  = "/sd/commands/"
 )
 
 func setEnv(key, value string) {
@@ -43,13 +44,16 @@ func TestLoadConfig(t *testing.T) {
 		t.Errorf("SDAPIURL=%q, want %q", SDAPIURL, dummyAPIURL)
 	}
 	if SDToken != dummyToken {
-		t.Errorf("SDAPIURL=%q, want %q", SDToken, dummyToken)
+		t.Errorf("SDToken=%q, want %q", SDToken, dummyToken)
 	}
 	if SDStoreURL != dummyStoreURL {
-		t.Errorf("SDAPIURL=%q, want %q", SDStoreURL, dummyStoreURL)
+		t.Errorf("SDStoreURL=%q, want %q", SDStoreURL, dummyStoreURL)
 	}
 	if SDArtifactsDir != dummySDArtifactsDir {
-		t.Errorf("SDAPIURL=%q, want %q", SDArtifactsDir, dummySDArtifactsDir)
+		t.Errorf("SDArtifactsDir=%q, want %q", SDArtifactsDir, dummySDArtifactsDir)
+	}
+	if BaseCommandPath != "/opt/sd/commands/" {
+		t.Errorf("BaseCommandPath=%q, want /opt/sd/commands/", BaseCommandPath)
 	}
 
 	// check unset env
@@ -57,6 +61,13 @@ func TestLoadConfig(t *testing.T) {
 	LoadConfig()
 	if SDAPIURL != "" {
 		t.Errorf("SDAPIURL=%q, want blank", SDAPIURL)
+	}
+
+	// set SD_BASE_COMMAND_PATH
+	setEnv("SD_BASE_COMMAND_PATH", dummyCustomCmdPath)
+	LoadConfig()
+	if BaseCommandPath != dummyCustomCmdPath {
+		t.Errorf("BaseCommandPath=%q, want %q", BaseCommandPath, dummyCustomCmdPath)
 	}
 }
 


### PR DESCRIPTION
- Put binaries downloaded under `/sd/commands` we are guaranteed that `/sd` will exist when the build starts since that's where the source code locates. 
- `/opt/sd` is a share mount between the base host and the vm for k8s-vm, ideally, we want the mount to be read-only and no remount to r/w should be allowed. Will take care of that later when we have a good solution.