### PR TITLE
fix: Change command log path and file name.

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -22,8 +22,8 @@ type Executor interface {
 }
 
 func prepareLog(smallSpec *util.CommandSpec) (err error) {
-	dirPath := filepath.Join(config.SDArtifactsDir, ".sd", "commands", smallSpec.Namespace, smallSpec.Name, smallSpec.Version)
-	filename := fmt.Sprintf("%v.log", time.Now().Unix())
+	dirPath := filepath.Join(config.SDArtifactsDir, ".sd", "commands")
+	filename := fmt.Sprintf("%v-%v-%v.log", time.Now().Unix(), smallSpec.Namespace, smallSpec.Name)
 	lgr, err = logger.New(dirPath, filename, log.LstdFlags, false)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Context
Currently, we have to click 6 times to display command log in the build page. It is too troublesome.
<img width="318" alt="2018-04-16 17 48 31" src="https://user-images.githubusercontent.com/8113204/38799102-71dc1960-419e-11e8-9bb5-d421a7639d0a.png">

Therefore, we changed the log path and log file name, and shortened the number of clicks to display the command log.

## Objective
Create the command log under `SDArtifactsDir/.sd/commands`, and name `{timestamp}-{namespace}-{name}.log`.
By changing this way, we can display command log by clicking 3 times.
And it is still distinguishable each log of commands when some commands are executed in the build.