### PR TITLE
feat(677): habitat format

### DIFF
--- a/executor/binary_test.go
+++ b/executor/binary_test.go
@@ -32,12 +32,12 @@ func dummyStoreCommand(body string) (cmd *store.Command) {
 	return &store.Command{
 		Type: "binary",
 		Body: []byte(body),
-		Spec: dummyAPICommandBinary(binaryFormat),
+		Spec: dummyAPICommand(binaryFormat),
 	}
 }
 
 func TestNewBinary(t *testing.T) {
-	_, err := NewBinary(dummyAPICommandBinary(binaryFormat), []string{"arg1", "arg2"})
+	_, err := NewBinary(dummyAPICommand(binaryFormat), []string{"arg1", "arg2"})
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
 	}
@@ -47,7 +47,7 @@ func TestRun(t *testing.T) {
 	logBuffer.Reset()
 
 	// success with no arguments
-	spec := dummyAPICommandBinary(binaryFormat)
+	spec := dummyAPICommand(binaryFormat)
 	bin, _ := NewBinary(spec, []string{})
 	bin.Store = store.Store(new(dummyStore))
 	err := bin.Run()
@@ -66,7 +66,7 @@ func TestRun(t *testing.T) {
 	}
 
 	// success with arguments
-	bin, _ = NewBinary(dummyAPICommandBinary(binaryFormat), []string{"arg1", "arg2"})
+	bin, _ = NewBinary(dummyAPICommand(binaryFormat), []string{"arg1", "arg2"})
 	bin.Store = store.Store(new(dummyStore))
 	err = bin.Run()
 	if err != nil {
@@ -74,7 +74,7 @@ func TestRun(t *testing.T) {
 	}
 
 	// failure. the command is broken
-	bin, _ = NewBinary(dummyAPICommandBinary(binaryFormat), []string{})
+	bin, _ = NewBinary(dummyAPICommand(binaryFormat), []string{})
 	bin.Store = store.Store(new(dummyStoreBroken))
 	err = bin.Run()
 	if err == nil {
@@ -82,7 +82,7 @@ func TestRun(t *testing.T) {
 	}
 
 	// failure. the store api return error
-	bin, _ = NewBinary(dummyAPICommandBinary(binaryFormat), []string{})
+	bin, _ = NewBinary(dummyAPICommand(binaryFormat), []string{})
 	bin.Store = store.Store(new(dummyStoreError))
 	err = bin.Run()
 	if err == nil {

--- a/executor/binary_test.go
+++ b/executor/binary_test.go
@@ -32,12 +32,12 @@ func dummyStoreCommand(body string) (cmd *store.Command) {
 	return &store.Command{
 		Type: "binary",
 		Body: []byte(body),
-		Spec: dummyAPICommand(binaryFormat),
+		Spec: dummyAPICommandBinary(binaryFormat),
 	}
 }
 
 func TestNewBinary(t *testing.T) {
-	_, err := NewBinary(dummyAPICommand(binaryFormat), []string{"arg1", "arg2"})
+	_, err := NewBinary(dummyAPICommandBinary(binaryFormat), []string{"arg1", "arg2"})
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
 	}
@@ -47,7 +47,7 @@ func TestRun(t *testing.T) {
 	logBuffer.Reset()
 
 	// success with no arguments
-	spec := dummyAPICommand(binaryFormat)
+	spec := dummyAPICommandBinary(binaryFormat)
 	bin, _ := NewBinary(spec, []string{})
 	bin.Store = store.Store(new(dummyStore))
 	err := bin.Run()
@@ -66,7 +66,7 @@ func TestRun(t *testing.T) {
 	}
 
 	// success with arguments
-	bin, _ = NewBinary(dummyAPICommand(binaryFormat), []string{"arg1", "arg2"})
+	bin, _ = NewBinary(dummyAPICommandBinary(binaryFormat), []string{"arg1", "arg2"})
 	bin.Store = store.Store(new(dummyStore))
 	err = bin.Run()
 	if err != nil {
@@ -74,7 +74,7 @@ func TestRun(t *testing.T) {
 	}
 
 	// failure. the command is broken
-	bin, _ = NewBinary(dummyAPICommand(binaryFormat), []string{})
+	bin, _ = NewBinary(dummyAPICommandBinary(binaryFormat), []string{})
 	bin.Store = store.Store(new(dummyStoreBroken))
 	err = bin.Run()
 	if err == nil {
@@ -82,7 +82,7 @@ func TestRun(t *testing.T) {
 	}
 
 	// failure. the store api return error
-	bin, _ = NewBinary(dummyAPICommand(binaryFormat), []string{})
+	bin, _ = NewBinary(dummyAPICommandBinary(binaryFormat), []string{})
 	bin.Store = store.Store(new(dummyStoreError))
 	err = bin.Run()
 	if err == nil {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/screwdriver-cd/sd-cmd/config"
 	"github.com/screwdriver-cd/sd-cmd/logger"
 	"github.com/screwdriver-cd/sd-cmd/screwdriver/api"
@@ -54,9 +55,9 @@ func New(sdAPI api.API, args []string) (Executor, error) {
 	case "habitat":
 		return NewHabitat(spec, args[pos+1:])
 	case "docker":
-		return nil, nil
+		return nil, errors.New("the docker format is not yet implemented")
 	default:
-		return nil, nil
+		return nil, errors.New("the format is not allowed")
 	}
 }
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -14,7 +14,10 @@ import (
 	"github.com/screwdriver-cd/sd-cmd/util"
 )
 
-var lgr *logger.Logger
+var (
+	command = exec.Command
+	lgr     *logger.Logger
+)
 
 // Executor is a Executor endpoint
 type Executor interface {
@@ -49,7 +52,7 @@ func New(sdAPI api.API, args []string) (Executor, error) {
 	case "binary":
 		return NewBinary(spec, args[pos+1:])
 	case "habitat":
-		return nil, nil
+		return NewHabitat(spec, args[pos+1:])
 	case "docker":
 		return nil, nil
 	default:
@@ -58,7 +61,7 @@ func New(sdAPI api.API, args []string) (Executor, error) {
 }
 
 func execCommand(path string, args []string) error {
-	cmd := exec.Command(path, args...)
+	cmd := command(path, args...)
 	lgr.Debug.Println("mmmmmm START COMMAND OUTPUT mmmmmm")
 
 	cmd.Stdout = os.Stdout
@@ -67,10 +70,11 @@ func execCommand(path string, args []string) error {
 	err := cmd.Run()
 
 	lgr.Debug.Println("mmmmmm FINISH COMMAND OUTPUT mmmmmm")
-	state := cmd.ProcessState
-	lgr.Debug.Printf("System Time: %v, User Time: %v\n", state.SystemTime(), state.UserTime())
 	if err != nil {
 		return fmt.Errorf("failed to exec command: %v", err)
 	}
+
+	state := cmd.ProcessState
+	lgr.Debug.Printf("System Time: %v, User Time: %v\n", state.SystemTime(), state.UserTime())
 	return nil
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -25,10 +25,7 @@ func prepareLog(smallSpec *util.CommandSpec) (err error) {
 	dirPath := filepath.Join(config.SDArtifactsDir, ".sd", "commands")
 	filename := fmt.Sprintf("%v-%v-%v.log", time.Now().Unix(), smallSpec.Namespace, smallSpec.Name)
 	lgr, err = logger.New(dirPath, filename, log.LstdFlags, false)
-	if err != nil {
-		return err
-	}
-	return nil
+	return
 }
 
 // New returns each format type of Executor
@@ -47,6 +44,7 @@ func New(sdAPI api.API, args []string) (Executor, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	switch spec.Format {
 	case "binary":
 		return NewBinary(spec, args[pos+1:])
@@ -54,8 +52,9 @@ func New(sdAPI api.API, args []string) (Executor, error) {
 		return nil, nil
 	case "docker":
 		return nil, nil
+	default:
+		return nil, nil
 	}
-	return nil, nil
 }
 
 func execCommand(path string, args []string) error {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -27,6 +27,9 @@ const (
 	dummyFileName    = "sd-step"
 	dummyFile        = "/dummy/" + dummyFileName
 	dummyDescription = "dummy description"
+	dummyMode        = "dummy_mode"
+	dummyPackage     = "core/dummy"
+	dummyCommand     = "dummy_get"
 )
 
 var (
@@ -74,10 +77,20 @@ func teardown() {
 type dummySDAPIBinary struct{}
 
 func (d *dummySDAPIBinary) GetCommand(smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
-	return dummyAPICommand(binaryFormat), nil
+	return dummyAPICommandBinary(binaryFormat), nil
 }
 
 func (d *dummySDAPIBinary) PostCommand(specPath string, smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
+	return nil, nil
+}
+
+type dummySDAPIHabitat struct{}
+
+func (d *dummySDAPIHabitat) GetCommand(smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
+	return dummyAPICommandHabitat(habitatFormat), nil
+}
+
+func (d *dummySDAPIHabitat) PostCommand(specPath string, smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
 	return nil, nil
 }
 
@@ -91,17 +104,32 @@ func (d *dummySDAPIBroken) PostCommand(specPath string, smallSpec *util.CommandS
 	return nil, fmt.Errorf("Something error happen")
 }
 
-func dummyAPICommand(format string) (cmd *util.CommandSpec) {
-	cmd = &util.CommandSpec{
+func dummyAPICommandBinary(format string) (cmd *util.CommandSpec) {
+	return &util.CommandSpec{
 		Namespace:   dummyNameSpace,
 		Name:        dummyName,
 		Description: dummyDescription,
 		Version:     dummyVersion,
 		Format:      format,
+		Binary: &util.Binary{
+			File: dummyFile,
+		},
 	}
-	cmd.Binary = new(util.Binary)
-	cmd.Binary.File = dummyFile
-	return cmd
+}
+
+func dummyAPICommandHabitat(format string) (cmd *util.CommandSpec) {
+	return &util.CommandSpec{
+		Namespace:   dummyNameSpace,
+		Name:        dummyName,
+		Description: dummyDescription,
+		Version:     dummyVersion,
+		Format:      format,
+		Habitat: &util.Habitat{
+			Mode:    dummyMode,
+			Package: dummyPackage,
+			Command: dummyCommand,
+		},
+	}
 }
 
 func TestNew(t *testing.T) {
@@ -117,6 +145,12 @@ func TestNew(t *testing.T) {
 
 	// success
 	sdapi = api.API(new(dummySDAPIBinary))
+	_, err = New(sdapi, []string{"exec", "ns/cmd@ver"})
+	if err != nil {
+		t.Errorf("err=%q, want nil", err)
+	}
+
+	sdapi = api.API(new(dummySDAPIHabitat))
 	_, err = New(sdapi, []string{"exec", "ns/cmd@ver"})
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -30,6 +30,7 @@ const (
 	dummyMode        = "dummy_mode"
 	dummyPackage     = "core/dummy"
 	dummyCommand     = "dummy_get"
+	dummyImage       = "dummy:latest"
 )
 
 var (
@@ -77,7 +78,7 @@ func teardown() {
 type dummySDAPIBinary struct{}
 
 func (d *dummySDAPIBinary) GetCommand(smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
-	return dummyAPICommandBinary(binaryFormat), nil
+	return dummyAPICommand(binaryFormat), nil
 }
 
 func (d *dummySDAPIBinary) PostCommand(specPath string, smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
@@ -87,7 +88,7 @@ func (d *dummySDAPIBinary) PostCommand(specPath string, smallSpec *util.CommandS
 type dummySDAPIHabitat struct{}
 
 func (d *dummySDAPIHabitat) GetCommand(smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
-	return dummyAPICommandHabitat(habitatFormat), nil
+	return dummyAPICommand(habitatFormat), nil
 }
 
 func (d *dummySDAPIHabitat) PostCommand(specPath string, smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
@@ -104,31 +105,46 @@ func (d *dummySDAPIBroken) PostCommand(specPath string, smallSpec *util.CommandS
 	return nil, fmt.Errorf("Something error happen")
 }
 
-func dummyAPICommandBinary(format string) (cmd *util.CommandSpec) {
-	return &util.CommandSpec{
-		Namespace:   dummyNameSpace,
-		Name:        dummyName,
-		Description: dummyDescription,
-		Version:     dummyVersion,
-		Format:      format,
-		Binary: &util.Binary{
-			File: dummyFile,
-		},
-	}
-}
-
-func dummyAPICommandHabitat(format string) (cmd *util.CommandSpec) {
-	return &util.CommandSpec{
-		Namespace:   dummyNameSpace,
-		Name:        dummyName,
-		Description: dummyDescription,
-		Version:     dummyVersion,
-		Format:      format,
-		Habitat: &util.Habitat{
-			Mode:    dummyMode,
-			Package: dummyPackage,
-			Command: dummyCommand,
-		},
+func dummyAPICommand(format string) (cmd *util.CommandSpec) {
+	switch format {
+	case binaryFormat:
+		return &util.CommandSpec{
+			Namespace:   dummyNameSpace,
+			Name:        dummyName,
+			Description: dummyDescription,
+			Version:     dummyVersion,
+			Format:      format,
+			Binary: &util.Binary{
+				File: dummyFile,
+			},
+		}
+	case habitatFormat:
+		return &util.CommandSpec{
+			Namespace:   dummyNameSpace,
+			Name:        dummyName,
+			Description: dummyDescription,
+			Version:     dummyVersion,
+			Format:      format,
+			Habitat: &util.Habitat{
+				Mode:    dummyMode,
+				Package: dummyPackage,
+				Command: dummyCommand,
+			},
+		}
+	case dockerFormat:
+		return &util.CommandSpec{
+			Namespace:   dummyNameSpace,
+			Name:        dummyName,
+			Description: dummyDescription,
+			Version:     dummyVersion,
+			Format:      format,
+			Docker: &util.Docker{
+				Image:   dummyImage,
+				Command: dummyCommand,
+			},
+		}
+	default:
+		return nil
 	}
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -106,46 +106,34 @@ func (d *dummySDAPIBroken) PostCommand(specPath string, smallSpec *util.CommandS
 }
 
 func dummyAPICommand(format string) (cmd *util.CommandSpec) {
+	cmd = &util.CommandSpec{
+		Namespace:   dummyNameSpace,
+		Name:        dummyName,
+		Description: dummyDescription,
+		Version:     dummyVersion,
+		Format:      format,
+	}
+
 	switch format {
 	case binaryFormat:
-		return &util.CommandSpec{
-			Namespace:   dummyNameSpace,
-			Name:        dummyName,
-			Description: dummyDescription,
-			Version:     dummyVersion,
-			Format:      format,
-			Binary: &util.Binary{
-				File: dummyFile,
-			},
+		cmd.Binary = &util.Binary{
+			File: dummyFile,
 		}
 	case habitatFormat:
-		return &util.CommandSpec{
-			Namespace:   dummyNameSpace,
-			Name:        dummyName,
-			Description: dummyDescription,
-			Version:     dummyVersion,
-			Format:      format,
-			Habitat: &util.Habitat{
-				Mode:    dummyMode,
-				Package: dummyPackage,
-				Command: dummyCommand,
-			},
+		cmd.Habitat = &util.Habitat{
+			Mode:    dummyMode,
+			Package: dummyPackage,
+			Command: dummyCommand,
 		}
 	case dockerFormat:
-		return &util.CommandSpec{
-			Namespace:   dummyNameSpace,
-			Name:        dummyName,
-			Description: dummyDescription,
-			Version:     dummyVersion,
-			Format:      format,
-			Docker: &util.Docker{
-				Image:   dummyImage,
-				Command: dummyCommand,
-			},
+		cmd.Docker = &util.Docker{
+			Image:   dummyImage,
+			Command: dummyCommand,
 		}
 	default:
 		return nil
 	}
+	return cmd
 }
 
 func TestNew(t *testing.T) {

--- a/executor/habitat.go
+++ b/executor/habitat.go
@@ -1,0 +1,60 @@
+package executor
+
+import (
+	"github.com/screwdriver-cd/sd-cmd/util"
+)
+
+var habPath = "/hab/bin/hab"
+
+// Habitat is the Habitat Executor struct
+type Habitat struct {
+	Args []string
+	Spec *util.Habitat
+}
+
+// NewHabitat returns the Habitat struct
+func NewHabitat(spec *util.CommandSpec, args []string) (habitat *Habitat, err error) {
+	habitat = &Habitat{
+		Args: args,
+		Spec: &util.Habitat{
+			Mode:    spec.Habitat.Mode,
+			Package: spec.Habitat.Package,
+			Command: spec.Habitat.Command,
+		},
+	}
+	return habitat, nil
+}
+
+// install executes "hab install" with a package name
+func (h *Habitat) install() (err error) {
+	pkgInstallArgs := []string{"pkg", "install", h.Spec.Package}
+
+	return execCommand(habPath, pkgInstallArgs)
+}
+
+// exec executes "hab exec" with a package name, command and args from a CLI
+func (h *Habitat) exec() (err error) {
+	execArgs := append([]string{"pkg", "exec", h.Spec.Package, h.Spec.Command}, h.Args...)
+
+	return execCommand(habPath, execArgs)
+}
+
+// Run executes "hab install" and "hab exec"
+func (h *Habitat) Run() (err error) {
+	lgr.Debug.Println("start installing habitat command.")
+
+	err = h.install()
+	if err != nil {
+		lgr.Debug.Println(err)
+		return
+	}
+
+	lgr.Debug.Println("start executing habitat command.")
+	err = h.exec()
+	if err != nil {
+		lgr.Debug.Println(err)
+	} else {
+		lgr.Debug.Println("execute habitat command succeeded.")
+	}
+	return
+}

--- a/executor/habitat_test.go
+++ b/executor/habitat_test.go
@@ -1,0 +1,105 @@
+package executor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+var dummyArgs = []string{"arg1", "arg2"}
+
+func fakeExecCommand(name string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestHelperProcess", "--", name}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	// fmt.Printf("%v \n %v", os.Args, cs)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}
+
+func TestNewHabitat(t *testing.T) {
+	_, err := NewHabitat(dummyAPICommandHabitat(habitatFormat), dummyArgs)
+	if err != nil {
+		t.Errorf("err=%q, want nil", err)
+	}
+}
+
+func TestRunHabitat(t *testing.T) {
+	logBuffer.Reset()
+	command = fakeExecCommand
+	defer func() { command = exec.Command }()
+
+	spec := dummyAPICommandHabitat(habitatFormat)
+	hab, _ := NewHabitat(spec, dummyArgs)
+	err := hab.Run()
+	if err != nil {
+		t.Errorf("err=%q, want nil", err)
+	}
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	defer os.Exit(0)
+
+	args := os.Args
+	for len(args) > 0 {
+		if args[0] == "--" {
+			args = args[1:]
+			break
+		}
+		args = args[1:]
+	}
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "no command\n")
+		os.Exit(2)
+	}
+
+	cmd, subcmd, subsubcmd, args := args[0], args[1], args[2], args[3:]
+
+	if cmd != "/hab/bin/hab" {
+		fmt.Fprintf(os.Stderr, "expected '/hab/bin/hab', but %v\n", cmd)
+		os.Exit(1)
+	}
+
+	if subcmd != "pkg" {
+		fmt.Fprintf(os.Stderr, "expected 'pkg', but %v\n", subcmd)
+		os.Exit(1)
+	}
+
+	switch subsubcmd {
+	case "exec":
+		execDummyArgs := append([]string{dummyPackage, dummyCommand}, dummyArgs...)
+		argsLen := len(args)
+		dummyLen := len(execDummyArgs)
+		if argsLen != dummyLen {
+			fmt.Fprintf(os.Stderr, "length of exec args is expected %v, but %v\n", dummyLen, argsLen)
+			os.Exit(1)
+		}
+		for i := range execDummyArgs {
+			if args[i] != execDummyArgs[i] {
+				fmt.Fprintf(os.Stderr, "exec cmd args is expected %v, but %v\n", dummyLen, argsLen)
+				os.Exit(1)
+			}
+		}
+	case "install":
+		installDummyArgs := []string{dummyPackage}
+		argsLen := len(args)
+		dummyLen := len(installDummyArgs)
+		if argsLen != dummyLen {
+			fmt.Fprintf(os.Stderr, "length of install cmd args is expected %v, but %v\n", dummyLen, argsLen)
+			os.Exit(1)
+		}
+		for i := range installDummyArgs {
+			if args[i] != installDummyArgs[i] {
+				fmt.Fprintf(os.Stderr, "install cmd args is expected %v, but %v\n", dummyLen, argsLen)
+				os.Exit(1)
+			}
+		}
+	default:
+		fmt.Fprintln(os.Stderr, "hab command is something wrong")
+		os.Exit(1)
+	}
+}

--- a/executor/habitat_test.go
+++ b/executor/habitat_test.go
@@ -19,7 +19,7 @@ func fakeExecCommand(name string, args ...string) *exec.Cmd {
 }
 
 func TestNewHabitat(t *testing.T) {
-	_, err := NewHabitat(dummyAPICommandHabitat(habitatFormat), dummyArgs)
+	_, err := NewHabitat(dummyAPICommand(habitatFormat), dummyArgs)
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
 	}
@@ -30,7 +30,7 @@ func TestRunHabitat(t *testing.T) {
 	command = fakeExecCommand
 	defer func() { command = exec.Command }()
 
-	spec := dummyAPICommandHabitat(habitatFormat)
+	spec := dummyAPICommand(habitatFormat)
 	hab, _ := NewHabitat(spec, dummyArgs)
 	err := hab.Run()
 	if err != nil {

--- a/sd-cmd.go
+++ b/sd-cmd.go
@@ -47,16 +47,13 @@ func init() {
 	config.LoadConfig()
 }
 
-func runExecutor(sdAPI api.API, args []string) error {
+func runExecutor(sdAPI api.API, args []string) (err error) {
 	exec, err := executor.New(sdAPI, args)
 	if err != nil {
-		return err
+		return
 	}
 	err = exec.Run()
-	if err != nil {
-		return err
-	}
-	return nil
+	return
 }
 
 func runPublisher(inputCommand []string) error {


### PR DESCRIPTION
## Context
habitat format and docker format of `sd-cmd` are not yet implemented.

## Objective
This PR provides `remote` mode of habitat format function.
I'll implement `local` mode after merging this PR.

It works in local SD like this:
- sd-command.yaml
```
(...snip)
format: habitat

habitat:
  mode: remote
  package: core/node8
  command: node
```
- screen shot
![image](https://user-images.githubusercontent.com/3445553/38910107-c6beeec0-4302-11e8-80de-e2553473b73e.png)



Related: https://github.com/screwdriver-cd/screwdriver/issues/677
Design Doc: https://github.com/screwdriver-cd/screwdriver/blob/master/design/commands.md