### PR TITLE
fix(677): return actual exit code

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -61,21 +61,22 @@ func New(sdAPI api.API, args []string) (Executor, error) {
 	}
 }
 
-func execCommand(path string, args []string) error {
+func execCommand(path string, args []string) (err error) {
 	cmd := command(path, args...)
 	lgr.Debug.Println("mmmmmm START COMMAND OUTPUT mmmmmm")
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	err := cmd.Run()
+	err = cmd.Run()
 
 	lgr.Debug.Println("mmmmmm FINISH COMMAND OUTPUT mmmmmm")
 	if err != nil {
-		return fmt.Errorf("failed to exec command: %v", err)
+		lgr.Debug.Printf("failed to exec command: %v", err)
+		return
 	}
 
 	state := cmd.ProcessState
 	lgr.Debug.Printf("System Time: %v, User Time: %v\n", state.SystemTime(), state.UserTime())
-	return nil
+	return
 }


### PR DESCRIPTION
## Context
`sd-cmd` doesn't return actual exit code. It returns only `1` with failure.

## Objective 
This PR fixes to return actual exit code.
- A command doesn't exist (This is the same behavior with current `sd-cmd`)
![image](https://user-images.githubusercontent.com/3445553/39106916-a5b6aa9c-46f9-11e8-96b8-45ace7807d93.png)

- An error happens in `sd-cmd`
![image](https://user-images.githubusercontent.com/3445553/39106822-376abbdc-46f9-11e8-832f-9b51958b5983.png)

## Reference
- https://stackoverflow.com/questions/10385551/get-exit-code-go
- Related: https://github.com/screwdriver-cd/screwdriver/issues/677