### PR TITLE
fix: improve binary command installation.

### DIFF
--- a/executor/binary_test.go
+++ b/executor/binary_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/screwdriver-cd/sd-cmd/config"
 	"github.com/screwdriver-cd/sd-cmd/screwdriver/store"
 )
@@ -43,6 +45,40 @@ func TestNewBinary(t *testing.T) {
 	}
 }
 
+func TestGetBinDirPath(t *testing.T) {
+	spec := dummyAPICommand(binaryFormat)
+	bin, _ := NewBinary(spec, []string{})
+	bin.Store = store.Store(new(dummyStore))
+	assert.Equal(t, bin.getBinDirPath(), "/tmp/sd/foo-dummy/name-dummy/1.0.1")
+}
+
+func TestGetBinFilePath(t *testing.T) {
+	spec := dummyAPICommand(binaryFormat)
+	bin, _ := NewBinary(spec, []string{})
+	bin.Store = store.Store(new(dummyStore))
+	assert.Equal(t, bin.getBinFilePath(), "/tmp/sd/foo-dummy/name-dummy/1.0.1/sd-step")
+}
+
+func TestIsInstalled(t *testing.T) {
+	spec := dummyAPICommand(binaryFormat)
+	bin, _ := NewBinary(spec, []string{})
+	bin.Store = store.Store(new(dummyStore))
+	// Not exists
+	assert.False(t, bin.isInstalled())
+
+	// 0 size file
+	os.MkdirAll(bin.getBinDirPath(), 0777)
+	file, _ := os.Create(bin.getBinFilePath())
+	assert.False(t, bin.isInstalled())
+
+	// non 0 size file
+	file.Write(([]byte)("dummy script."))
+	assert.True(t, bin.isInstalled())
+
+	defer file.Close()
+	defer os.RemoveAll(bin.getBinDirPath())
+}
+
 func TestRun(t *testing.T) {
 	logBuffer.Reset()
 
@@ -64,6 +100,8 @@ func TestRun(t *testing.T) {
 	if fInfo.IsDir() {
 		t.Errorf("%q is directory, must be file", binPath)
 	}
+	assert.True(t, bin.isInstalled())
+	os.Remove(binPath)
 
 	// success with arguments
 	bin, _ = NewBinary(dummyAPICommand(binaryFormat), []string{"arg1", "arg2"})
@@ -72,6 +110,8 @@ func TestRun(t *testing.T) {
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
 	}
+	assert.True(t, bin.isInstalled())
+	os.Remove(binPath)
 
 	// failure. the command is broken
 	bin, _ = NewBinary(dummyAPICommand(binaryFormat), []string{})
@@ -80,6 +120,7 @@ func TestRun(t *testing.T) {
 	if err == nil {
 		t.Errorf("err=nil, want error")
 	}
+	os.Remove(binPath)
 
 	// failure. the store api return error
 	bin, _ = NewBinary(dummyAPICommand(binaryFormat), []string{})
@@ -88,4 +129,5 @@ func TestRun(t *testing.T) {
 	if err == nil {
 		t.Errorf("err=nil, want error")
 	}
+	os.Remove(binPath)
 }

--- a/executor/binary_test.go
+++ b/executor/binary_test.go
@@ -49,14 +49,16 @@ func TestGetBinDirPath(t *testing.T) {
 	spec := dummyAPICommand(binaryFormat)
 	bin, _ := NewBinary(spec, []string{})
 	bin.Store = store.Store(new(dummyStore))
-	assert.Equal(t, bin.getBinDirPath(), "/tmp/sd/foo-dummy/name-dummy/1.0.1")
+	// Note: config.BaseCommandPath is customized for test.
+	// see executor/executor_test.go
+	assert.Equal(t, bin.getBinDirPath(), filepath.Join(config.BaseCommandPath, "foo-dummy/name-dummy/1.0.1"))
 }
 
 func TestGetBinFilePath(t *testing.T) {
 	spec := dummyAPICommand(binaryFormat)
 	bin, _ := NewBinary(spec, []string{})
 	bin.Store = store.Store(new(dummyStore))
-	assert.Equal(t, bin.getBinFilePath(), "/tmp/sd/foo-dummy/name-dummy/1.0.1/sd-step")
+	assert.Equal(t, bin.getBinFilePath(), filepath.Join(config.BaseCommandPath, "foo-dummy/name-dummy/1.0.1/sd-step"))
 }
 
 func TestIsInstalled(t *testing.T) {


### PR DESCRIPTION
## Context

Currently, `sd-cmd binary` downloads a binary file via the Store API each time it executes its file.
This behavior misspends network traffic and time, if you will execute `sd-cmd binary` repeatedly.

## Objective

This PR makes it possible to download and install a binary file only once.

