### PR TITLE
feat(677): implement promote command

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -95,8 +95,8 @@ func (d *dummySDAPI) ValidateCommand(yamlString string) (*util.ValidateResponse,
 	return nil, nil
 }
 
-func (d *dummySDAPI) TagCommand(spec *util.CommandSpec, targetVersion, tag string) error {
-	return nil
+func (d *dummySDAPI) TagCommand(spec *util.CommandSpec, targetVersion, tag string) (*util.TagResponse, error) {
+	return nil, nil
 }
 
 func newDummySDAPI(spec *util.CommandSpec, err error) api.API {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -95,6 +95,10 @@ func (d *dummySDAPI) ValidateCommand(yamlString string) (*util.ValidateResponse,
 	return nil, nil
 }
 
+func (d *dummySDAPI) TagCommand(spec *util.CommandSpec, targetVersion, tag string) error {
+	return nil
+}
+
 func newDummySDAPI(spec *util.CommandSpec, err error) api.API {
 	d := &dummySDAPI{
 		spec: spec,

--- a/promoter/promoter.go
+++ b/promoter/promoter.go
@@ -49,12 +49,13 @@ func New(api api.API, args []string) (p *Promoter, err error) {
 func (p *Promoter) Run() (err error) {
 	spec, err := p.sdAPI.GetCommand(p.smallSpec)
 	if err != nil {
-		fmt.Printf("%v does not exist yet.\n", p.tag)
+		fmt.Printf("%v does not exist yet\n", p.tag)
 	} else {
 		fmt.Printf("Removing %v from %v\n", spec.Version, p.tag)
 	}
 	res, err := p.sdAPI.TagCommand(p.smallSpec, p.targetVersion, p.tag)
 	if err != nil {
+		fmt.Println("Promoting is aborted")
 		return
 	}
 

--- a/promoter/promoter.go
+++ b/promoter/promoter.go
@@ -50,6 +50,9 @@ func (p *Promoter) Run() (err error) {
 	spec, err := p.sdAPI.GetCommand(p.smallSpec)
 	if err != nil {
 		fmt.Printf("%v does not exist yet\n", p.tag)
+	} else if spec.Version == p.targetVersion {
+		fmt.Printf("%v has been already tagged with %v\n", spec.Version, p.tag)
+		return
 	} else {
 		fmt.Printf("Removing %v from %v\n", spec.Version, p.tag)
 	}

--- a/promoter/promoter.go
+++ b/promoter/promoter.go
@@ -1,0 +1,63 @@
+package promoter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/screwdriver-cd/sd-cmd/screwdriver/api"
+	"github.com/screwdriver-cd/sd-cmd/util"
+)
+
+// Promoter is a type to tag commands
+type Promoter struct {
+	smallSpec     *util.CommandSpec
+	sdAPI         api.API
+	targetVersion string
+	tag           string
+}
+
+// New generates new Promoter.
+// args is expected as ["namespace/name", "targetVersion", "tag"]
+func New(api api.API, args []string) (p *Promoter, err error) {
+	if len(args) != 3 {
+		return nil, fmt.Errorf("parameters are not enough")
+	}
+	targetVersion, tag := args[1], args[2]
+
+	commandName := strings.Split(args[0], "/") // namespace/name
+	if len(commandName) != 2 {
+		return nil, fmt.Errorf("%v is invalid command name", args[0])
+	}
+
+	smallSpec := &util.CommandSpec{
+		Namespace: commandName[0],
+		Name:      commandName[1],
+		Version:   tag,
+	}
+
+	p = &Promoter{
+		smallSpec:     smallSpec,
+		sdAPI:         api,
+		targetVersion: targetVersion,
+		tag:           tag,
+	}
+
+	return
+}
+
+// Run executes tag command API
+func (p *Promoter) Run() (err error) {
+	spec, err := p.sdAPI.GetCommand(p.smallSpec)
+	if err != nil {
+		fmt.Printf("%v does not exist yet.\n", p.tag)
+	} else {
+		fmt.Printf("Removing %v from %v\n", spec.Version, p.tag)
+	}
+	res, err := p.sdAPI.TagCommand(p.smallSpec, p.targetVersion, p.tag)
+	if err != nil {
+		return
+	}
+
+	fmt.Printf("Promoting %v to %v\n", res.Version, res.Tag)
+	return
+}

--- a/promoter/promoter.go
+++ b/promoter/promoter.go
@@ -29,6 +29,10 @@ func New(api api.API, args []string) (p *Promoter, err error) {
 		return nil, fmt.Errorf("%v is invalid command name", args[0])
 	}
 
+	if !util.ValidateTagName(tag) {
+		return nil, fmt.Errorf("%v is invalid tag name", tag)
+	}
+
 	smallSpec := &util.CommandSpec{
 		Namespace: commandName[0],
 		Name:      commandName[1],

--- a/promoter/promoter_test.go
+++ b/promoter/promoter_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const (
+var (
 	dummyNameSpace      = "foo-dummy"
 	dummyName           = "name-dummy"
 	dummyVersion        = "1.0.0"
@@ -101,7 +101,17 @@ func TestRun(t *testing.T) {
 	err = p.Run()
 	assert.Nil(t, err)
 
+	// success with already tagged version
+	dummyTargetVersion = "1.0.0"
+	p, err = New(sdapi, []string{dummyCmdName, dummyTargetVersion, dummyTag})
+	if err != nil {
+		assert.Fail(t, "err should be nil")
+	}
+	err = p.Run()
+	assert.Nil(t, err)
+
 	// failure with error response from TagCommand
+	dummyTargetVersion = "1.0.1"
 	sdapi = api.API(new(dummyInvalidSDAPI))
 	p, err = New(sdapi, []string{dummyCmdName, dummyTargetVersion, dummyTag})
 	if err != nil {

--- a/promoter/promoter_test.go
+++ b/promoter/promoter_test.go
@@ -17,6 +17,7 @@ var (
 	dummyCmdName        = dummyNameSpace + "/" + dummyName
 	invalidDummyCmdName = "invalid/invalid/invalid"
 	dummyTag            = "stable"
+	invalidDummyTag     = "-invalid-"
 )
 
 type dummySDAPI struct{}
@@ -89,6 +90,10 @@ func TestNew(t *testing.T) {
 	// failure with invalid command name
 	_, err = New(sdapi, []string{invalidDummyCmdName, dummyTargetVersion, dummyTag})
 	assert.EqualError(t, err, invalidDummyCmdName+" is invalid command name")
+
+	// failure with invalid tag name
+	_, err = New(sdapi, []string{dummyCmdName, dummyTargetVersion, invalidDummyTag})
+	assert.EqualError(t, err, invalidDummyTag+" is invalid tag name")
 }
 
 func TestRun(t *testing.T) {

--- a/promoter/promoter_test.go
+++ b/promoter/promoter_test.go
@@ -1,0 +1,112 @@
+package promoter
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/screwdriver-cd/sd-cmd/screwdriver/api"
+	"github.com/screwdriver-cd/sd-cmd/util"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	dummyNameSpace      = "foo-dummy"
+	dummyName           = "name-dummy"
+	dummyVersion        = "1.0.0"
+	dummyTargetVersion  = "1.0.1"
+	dummyCmdName        = dummyNameSpace + "/" + dummyName
+	invalidDummyCmdName = "invalid/invalid/invalid"
+	dummyTag            = "stable"
+)
+
+type dummySDAPI struct{}
+
+func (d *dummySDAPI) GetCommand(smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
+	return &util.CommandSpec{
+		Version: dummyVersion,
+	}, nil
+}
+
+func (d *dummySDAPI) PostCommand(smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
+	return nil, nil
+}
+
+func (d *dummySDAPI) ValidateCommand(yamlString string) (*util.ValidateResponse, error) {
+	return nil, nil
+}
+
+func (d *dummySDAPI) TagCommand(spec *util.CommandSpec, targetVersion, tag string) (*util.TagResponse, error) {
+	return &util.TagResponse{
+		Namespace: dummyNameSpace,
+		Name:      dummyName,
+		Tag:       dummyTag,
+		Version:   dummyTargetVersion,
+	}, nil
+}
+
+type dummyInvalidSDAPI struct{}
+
+func (d *dummyInvalidSDAPI) GetCommand(smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
+	return &util.CommandSpec{
+		Version: dummyVersion,
+	}, nil
+}
+
+func (d *dummyInvalidSDAPI) PostCommand(smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
+	return nil, nil
+}
+
+func (d *dummyInvalidSDAPI) ValidateCommand(yamlString string) (*util.ValidateResponse, error) {
+	return nil, nil
+}
+
+func (d *dummyInvalidSDAPI) TagCommand(spec *util.CommandSpec, targetVersion, tag string) (*util.TagResponse, error) {
+	return nil, errors.New("error")
+}
+
+func TestNew(t *testing.T) {
+	sdapi := api.API(new(dummySDAPI))
+
+	// success
+	expected := &Promoter{
+		smallSpec: &util.CommandSpec{
+			Namespace: dummyNameSpace,
+			Name:      dummyName,
+			Version:   dummyTag,
+		},
+		sdAPI:         sdapi,
+		targetVersion: dummyTargetVersion,
+		tag:           dummyTag,
+	}
+	p, err := New(sdapi, []string{dummyCmdName, dummyTargetVersion, dummyTag})
+	assert.Nil(t, err)
+	assert.Equal(t, p, expected)
+
+	// failure with no args
+	_, err = New(sdapi, []string{})
+	assert.EqualError(t, err, "parameters are not enough")
+
+	// failure with invalid command name
+	_, err = New(sdapi, []string{invalidDummyCmdName, dummyTargetVersion, dummyTag})
+	assert.EqualError(t, err, invalidDummyCmdName+" is invalid command name")
+}
+
+func TestRun(t *testing.T) {
+	// success
+	sdapi := api.API(new(dummySDAPI))
+	p, err := New(sdapi, []string{dummyCmdName, dummyTargetVersion, dummyTag})
+	if err != nil {
+		assert.Fail(t, "err should be nil")
+	}
+	err = p.Run()
+	assert.Nil(t, err)
+
+	// failure with error response from TagCommand
+	sdapi = api.API(new(dummyInvalidSDAPI))
+	p, err = New(sdapi, []string{dummyCmdName, dummyTargetVersion, dummyTag})
+	if err != nil {
+		assert.Fail(t, "err should be nil")
+	}
+	err = p.Run()
+	assert.EqualError(t, err, "error")
+}

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -48,8 +48,8 @@ func (d *dummySDAPI) ValidateCommand(yamlString string) (*util.ValidateResponse,
 	return nil, nil
 }
 
-func (d *dummySDAPI) TagCommand(spec *util.CommandSpec, targetVersion, tag string) error {
-	return nil
+func (d *dummySDAPI) TagCommand(spec *util.CommandSpec, targetVersion, tag string) (*util.TagResponse, error) {
+	return nil, nil
 }
 
 func newDummySDAPI(spec *util.CommandSpec, err error) api.API {

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -48,6 +48,10 @@ func (d *dummySDAPI) ValidateCommand(yamlString string) (*util.ValidateResponse,
 	return nil, nil
 }
 
+func (d *dummySDAPI) TagCommand(spec *util.CommandSpec, targetVersion, tag string) error {
+	return nil
+}
+
 func newDummySDAPI(spec *util.CommandSpec, err error) api.API {
 	d := &dummySDAPI{
 		spec: spec,

--- a/screwdriver/api/api.go
+++ b/screwdriver/api/api.go
@@ -25,7 +25,7 @@ type API interface {
 	GetCommand(smallSpec *util.CommandSpec) (*util.CommandSpec, error)
 	PostCommand(commandSpec *util.CommandSpec) (*util.CommandSpec, error)
 	ValidateCommand(yamlString string) (*util.ValidateResponse, error)
-	TagCommand(commandSpec *util.CommandSpec, targetVersion, tag string) error
+	TagCommand(commandSpec *util.CommandSpec, targetVersion, tag string) (*util.TagResponse, error)
 }
 
 type client struct {
@@ -284,15 +284,15 @@ func (c client) ValidateCommand(yamlString string) (*util.ValidateResponse, erro
 	return res, nil
 }
 
-func (c client) TagCommand(commandSpec *util.CommandSpec, targetVersion, tag string) (err error) {
+func (c client) TagCommand(commandSpec *util.CommandSpec, targetVersion, tag string) (res *util.TagResponse, err error) {
 	body, err := versionToPayLoadBuf(targetVersion)
 	if err != nil {
-		return fmt.Errorf("Failed to create payload: %v", err)
+		return nil, fmt.Errorf("Failed to create payload: %v", err)
 	}
 
 	uri, err := url.Parse(c.baseURL)
 	if err != nil {
-		return fmt.Errorf("Failed to parse URL: %v", err)
+		return nil, fmt.Errorf("Failed to parse URL: %v", err)
 	}
 	uri.Path = path.Join(uri.Path, "commands", commandSpec.Namespace, commandSpec.Name, "tags", tag)
 
@@ -306,7 +306,7 @@ func (c client) TagCommand(commandSpec *util.CommandSpec, targetVersion, tag str
 		return
 	}
 
-	res := new(util.TagResponse)
+	res = new(util.TagResponse)
 	err = json.Unmarshal(responseBytes, res)
 	return
 }

--- a/screwdriver/api/api_test.go
+++ b/screwdriver/api/api_test.go
@@ -8,10 +8,10 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/screwdriver-cd/sd-cmd/util"
-	"path"
 )
 
 const (
@@ -322,7 +322,7 @@ func TestTagCommand(t *testing.T) {
 	api := API(c)
 
 	// request
-	err := api.TagCommand(spec, dummyVersion, dummyTag)
+	_, err := api.TagCommand(spec, dummyVersion, dummyTag)
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
 	}
@@ -334,7 +334,7 @@ func TestTagCommand(t *testing.T) {
 	api = API(c)
 
 	// request
-	err = api.TagCommand(spec, dummyVersion, dummyTag)
+	_, err = api.TagCommand(spec, dummyVersion, dummyTag)
 	if err.Error() != ansMsg {
 		t.Errorf("err=%q, want %q", errMsg, ansMsg)
 	}
@@ -343,7 +343,7 @@ func TestTagCommand(t *testing.T) {
 	for _, res := range errorResponses {
 		c.client = makeFakeHTTPClient(t, res.code, res.message, "")
 		api = API(c)
-		err = api.TagCommand(spec, dummyVersion, dummyTag)
+		_, err = api.TagCommand(spec, dummyVersion, dummyTag)
 		if err == nil {
 			println(res.code, res.message)
 			t.Errorf("err=nil, want error")

--- a/sd-cmd.go
+++ b/sd-cmd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/screwdriver-cd/sd-cmd/config"
 	"github.com/screwdriver-cd/sd-cmd/executor"
 	"github.com/screwdriver-cd/sd-cmd/logger"
+	"github.com/screwdriver-cd/sd-cmd/promoter"
 	"github.com/screwdriver-cd/sd-cmd/publisher"
 	"github.com/screwdriver-cd/sd-cmd/screwdriver/api"
 	"github.com/screwdriver-cd/sd-cmd/validator"
@@ -76,7 +77,12 @@ func runPublisher(sdAPI api.API, args []string) error {
 }
 
 func runPromoter(sdAPI api.API, args []string) error {
-	return nil
+	pro, err := promoter.New(sdAPI, args)
+	if err != nil {
+		return fmt.Errorf("Fail to get promoter: %v", err)
+	}
+
+	return pro.Run()
 }
 
 func runValidator(sdAPI api.API, args []string) error {
@@ -98,7 +104,7 @@ func runCommand(sdAPI api.API, args []string) error {
 	case "publish":
 		return runPublisher(sdAPI, args[2:])
 	case "promote":
-		return fmt.Errorf("promote is not implemented yet")
+		return runPromoter(sdAPI, args[2:])
 	case "validate":
 		return runValidator(sdAPI, args[2:])
 	default:

--- a/sd-cmd.go
+++ b/sd-cmd.go
@@ -67,18 +67,20 @@ func runExecutor(sdAPI api.API, args []string) (err error) {
 	return
 }
 
-func runPublisher(inputCommand []string) error {
-	sdAPI := api.New(config.SDAPIURL, config.SDToken)
-	pub, err := publisher.New(sdAPI, inputCommand)
+func runPublisher(sdAPI api.API, args []string) error {
+	pub, err := publisher.New(sdAPI, args)
 	if err != nil {
 		return fmt.Errorf("Fail to get publisher: %v", err)
 	}
 	return pub.Run()
 }
 
-func runValidator(inputCommand []string) error {
-	sdAPI := api.New(config.SDAPIURL, config.SDToken)
-	val, err := validator.New(sdAPI, inputCommand)
+func runPromoter(sdAPI api.API, args []string) error {
+	return nil
+}
+
+func runValidator(sdAPI api.API, args []string) error {
+	val, err := validator.New(sdAPI, args)
 	if err != nil {
 		return fmt.Errorf("Fail to get validator: %v", err)
 	}
@@ -94,11 +96,11 @@ func runCommand(sdAPI api.API, args []string) error {
 	case "exec":
 		return runExecutor(sdAPI, args)
 	case "publish":
-		return runPublisher(args[2:])
+		return runPublisher(sdAPI, args[2:])
 	case "promote":
 		return fmt.Errorf("promote is not implemented yet")
 	case "validate":
-		return runValidator(args[2:])
+		return runValidator(sdAPI, args[2:])
 	default:
 		return runExecutor(sdAPI, args)
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -85,6 +85,20 @@ type ValidateError struct {
 	Message string `json:"message"`
 }
 
+// TagTargetVersion represents a body of a tagging request.
+type TagTargetVersion struct {
+	Version string `json:"version"`
+}
+
+// TagResponse represents a response from API when tags command
+type TagResponse struct {
+	ID        int    `json:"id"`
+	Namespace string `json"namespace"`
+	Name      string `json:"name"`
+	Tag       string `json:"tag"`
+	Version   string `json:"version"`
+}
+
 func checkVersion(ver string) bool {
 	if caretRangesAndPinningRegexp.Match([]byte(ver)) {
 		return true

--- a/util/util.go
+++ b/util/util.go
@@ -92,8 +92,7 @@ type TagTargetVersion struct {
 
 // TagResponse represents a response from API when tags command
 type TagResponse struct {
-	ID        int    `json:"id"`
-	Namespace string `json"namespace"`
+	Namespace string `json:"namespace"`
 	Name      string `json:"name"`
 	Tag       string `json:"tag"`
 	Version   string `json:"version"`

--- a/util/util.go
+++ b/util/util.go
@@ -26,7 +26,7 @@ var caretRangesAndPinningRegexp = regexp.MustCompile(`^(\^)?\d(\.\d){2}$`)
 
 // tagRegexp check VERSION of Tags. Tags can only be named with A-Z,a-z,0-9,-
 // ex(latest stable feature-abc)
-var tagRegexp = regexp.MustCompile(`^[a-z][a-z0-9-]+$`)
+var tagRegexp = regexp.MustCompile(`^[a-zA-Z][\w-]+$`)
 
 // A Habitat represents a set of data for Habitat.
 // All value will be omitted if it is not set.
@@ -148,4 +148,12 @@ func SplitCmdWithSearch(cmds []string) (smallSpec *CommandSpec, pos int, err err
 		}
 	}
 	return nil, -1, fmt.Errorf("There is no valid command format")
+}
+
+// ValidateTagName validates tag name
+func ValidateTagName(tag string) bool {
+	if tagRegexp.Match([]byte(tag)) {
+		return true
+	}
+	return false
 }

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -28,6 +28,10 @@ func (d *dummySDAPIValidator) ValidateCommand(yamlString string) (*util.Validate
 	return dummyAPIValidateCommand(), nil
 }
 
+func (d *dummySDAPIValidator) TagCommand(spec *util.CommandSpec, targetVersion, tag string) error {
+	return nil
+}
+
 func TestNew(t *testing.T) {
 	// success
 	testDataPath := "../testdata/yaml/sd-command.yaml"

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -28,8 +28,8 @@ func (d *dummySDAPIValidator) ValidateCommand(yamlString string) (*util.Validate
 	return dummyAPIValidateCommand(), nil
 }
 
-func (d *dummySDAPIValidator) TagCommand(spec *util.CommandSpec, targetVersion, tag string) error {
-	return nil
+func (d *dummySDAPIValidator) TagCommand(spec *util.CommandSpec, targetVersion, tag string) (*util.TagResponse, error) {
+	return nil, nil
 }
 
 func TestNew(t *testing.T) {


### PR DESCRIPTION
This PR adds `sd-cmd promote namespace/name version tag` command.
It works locally like below:
- when we tag first time
![image](https://user-images.githubusercontent.com/3445553/41076019-628edcf2-6a4a-11e8-84b4-fcb45e4fba95.png)
- when we use already used tag
![image](https://user-images.githubusercontent.com/3445553/41076029-7587021c-6a4a-11e8-9872-cc8181d38107.png)
- (added) when we tag with same version
![image](https://user-images.githubusercontent.com/3445553/41082149-44561476-6a68-11e8-8fbc-66eac5ffdcd8.png)

Related:
- design: https://github.com/screwdriver-cd/screwdriver/blob/master/design/commands.md 
- Issue: https://github.com/screwdriver-cd/screwdriver/issues/677
