### PR TITLE
feat(677): implement publish with tag feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # sd-cmd
+[![Build Status][build-image]][build-url]
+[![Go Report Card][goreport-image]][goreport-url]  
 Screwdriver commands (Sharing Binaries)
 
 ## Usage
@@ -23,3 +25,8 @@ go test -cover github.com/screwdriver-cd/sd-cmd/...
 
 ## License
 Code licensed under the BSD 3-Clause license. See LICENSE file for terms.
+
+[build-image]: https://cd.screwdriver.cd/pipelines/408/badge
+[build-url]: https://cd.screwdriver.cd/pipelines/408
+[goreport-image]: https://goreportcard.com/badge/github.com/Screwdriver-cd/sd-cmd
+[goreport-url]: https://goreportcard.com/report/github.com/Screwdriver-cd/sd-cmd

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -38,6 +38,9 @@ func (p *Publisher) Run() error {
 	}
 
 	err = p.tagCommand(specResponse)
+	if err != nil {
+		return fmt.Errorf("Tag failed: %v", err)
+	}
 
 	// Published successfully
 	// Show version number of command published by sd-cmd

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -20,6 +20,16 @@ type Publisher struct {
 	tag         string
 }
 
+func (p *Publisher) tagCommand(specResponse *util.CommandSpec) error {
+	commandFullName := path.Join(specResponse.Namespace, specResponse.Name)
+	promoter, err := promoter.New(p.sdAPI, []string{commandFullName, specResponse.Version, p.tag})
+	if err != nil {
+		return err
+	}
+
+	return promoter.Run()
+}
+
 // Run is a method to publish sdapi and sdstore.
 func (p *Publisher) Run() error {
 	specResponse, err := p.sdAPI.PostCommand(p.commandSpec)
@@ -27,13 +37,7 @@ func (p *Publisher) Run() error {
 		return fmt.Errorf("Post failed: %v", err)
 	}
 
-	commandFullName := path.Join(specResponse.Namespace, specResponse.Name)
-	promoter, err := promoter.New(p.sdAPI, []string{commandFullName, specResponse.Version, p.tag})
-	if err != nil {
-		return err
-	}
-
-	promoter.Run()
+	err = p.tagCommand(specResponse)
 
 	// Published successfully
 	// Show version number of command published by sd-cmd

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -24,6 +24,7 @@ const (
 	dummyHabitatMode = "remote"
 	dummyHabitatPkg  = "core/git/2.14.1"
 	dummyCmd         = "dummy-command"
+	dummyTag         = "latest"
 )
 
 const (
@@ -49,7 +50,12 @@ func (d *dummySDAPI) ValidateCommand(yamlString string) (*util.ValidateResponse,
 }
 
 func (d *dummySDAPI) TagCommand(spec *util.CommandSpec, targetVersion, tag string) (*util.TagResponse, error) {
-	return nil, nil
+	return &util.TagResponse{
+		Namespace: dummyNameSpace,
+		Name:      dummyName,
+		Tag:       dummyTag,
+		Version:   dummyVersion,
+	}, nil
 }
 
 func newDummySDAPI(spec *util.CommandSpec, err error) api.API {


### PR DESCRIPTION
This PR provides a feature of publish with tag specified by `-t` option. It works locally like below:

- default is `latest` (`$ sd-cmd publish -f sd-command.yaml` )
![image](https://user-images.githubusercontent.com/3445553/41085905-48cc899e-6a73-11e8-9259-ac1adc52117d.png)

- specify tag (`$ sd-cmd publish -f sd-command.yaml -t supertag`)
![image](https://user-images.githubusercontent.com/3445553/41085911-4da85628-6a73-11e8-9ba2-268276d06e9f.png)

This PR also add badges to README.

## Related
- Issue: https://github.com/screwdriver-cd/screwdriver/issues/677
- design: https://github.com/screwdriver-cd/screwdriver/blob/master/design/commands.md