### PR TITLE
feat(677): [1] Key of binary part of multipart payload should be "binary"

### DIFF
--- a/screwdriver/api/api.go
+++ b/screwdriver/api/api.go
@@ -168,7 +168,7 @@ func writeMultipartBin(writer *multipart.Writer, commandSpec *util.CommandSpec) 
 	}
 
 	fileName := filepath.Base(filePath)
-	filePart, err := writer.CreateFormFile(commandSpec.Format, fileName)
+	filePart, err := writer.CreateFormFile("binary", fileName)
 	if err != nil {
 		return fmt.Errorf("Failed to create form of %s:%v", commandSpec.Format, err)
 	}

--- a/screwdriver/api/api.go
+++ b/screwdriver/api/api.go
@@ -168,7 +168,7 @@ func writeMultipartBin(writer *multipart.Writer, commandSpec *util.CommandSpec) 
 	}
 
 	fileName := filepath.Base(filePath)
-	filePart, err := writer.CreateFormFile("binary", fileName)
+	filePart, err := writer.CreateFormFile("file", fileName)
 	if err != nil {
 		return fmt.Errorf("Failed to create form of %s:%v", commandSpec.Format, err)
 	}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Screwdriver API should get binary part of multipart payload with only "binary" key. Using "habitat" or "docker" key is not reasonable.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Screwdriver API can get binary part just like `data.binary`. There is no need to add `if` block for getting data.

## Related PRs
https://github.com/screwdriver-cd/screwdriver/pull/1135

## Related issue
https://github.com/screwdriver-cd/screwdriver/issues/677