### PR TITLE
fix: fix habitat local pkg install path

### DIFF
--- a/executor/habitat.go
+++ b/executor/habitat.go
@@ -81,7 +81,7 @@ func (h *Habitat) download() error {
 func (h *Habitat) install() (err error) {
 	var installPkg string
 	if h.Spec.Habitat.Mode == "local" {
-		installPkg = h.Spec.Habitat.File
+		installPkg = h.getPkgFilePath()
 	} else {
 		installPkg = h.Spec.Habitat.Package
 	}

--- a/executor/habitat_test.go
+++ b/executor/habitat_test.go
@@ -158,7 +158,7 @@ func TestHelperProcess(t *testing.T) {
 	case "install":
 		var installDummyArgs []string
 		if os.Getenv("HABITAT_MODE") == "local" {
-			installDummyArgs[0] = dummyHart
+			installDummyArgs[0] = filepath.Join(config.BaseCommandPath, "foo-dummy/name-dummy/1.0.1/dummy.hart")
 		} else {
 			installDummyArgs[0] = dummyPackage
 		}


### PR DESCRIPTION
we should refer downloaded pkg path when use habitat local command.