### PR TITLE
feat(1095): Add optional usage field to command

### DIFF
--- a/testdata/yaml/sd-command.yaml
+++ b/testdata/yaml/sd-command.yaml
@@ -5,6 +5,13 @@ name: bar
 # Description of the command and what it does
 description: |
   Lorem ipsum dolor sit amet.
+usage: 'sd_cmd exec foo/bar@1 <OPTION> <TARGET>
+Options:
+        --config              some config file
+        --debug               debug mode (default "false")
+        --host                super host
+        --log-level           set the logging level ("debug"|"info"|"warn"|"error"|"fatal") (default "info")
+Target:                       path to file'
 # Maintainer of the command
 maintainer: foo@bar.com
 # Major and Minor version number (patch is automatic)

--- a/util/util.go
+++ b/util/util.go
@@ -60,6 +60,7 @@ type CommandSpec struct {
 	Namespace   string   `json:"namespace" yaml:"namespace"`
 	Name        string   `json:"name" yaml:"name"`
 	Description string   `json:"description" yaml:"description"`
+	Usage       string   `json:"usage,omitempty" yaml:"usage,omitempty"`
 	Maintainer  string   `json:"maintainer" yaml:"maintainer"`
 	Version     string   `json:"version" yaml:"version"`
 	Format      string   `json:"format" yaml:"format"`


### PR DESCRIPTION
## Context
Would be nice if users could customize the usage field in the UI.

## Objective
This PR adds `usage` to command spec.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1095