### PR TITLE
fix: Fix hab path

### DIFF
--- a/executor/habitat.go
+++ b/executor/habitat.go
@@ -10,7 +10,7 @@ import (
 	"github.com/screwdriver-cd/sd-cmd/util"
 )
 
-const habPath = "/hab/bin/hab"
+const habPath = "/opt/hab/bin/hab"
 
 // Habitat is the Habitat Executor struct
 type Habitat struct {

--- a/executor/habitat_test.go
+++ b/executor/habitat_test.go
@@ -130,8 +130,8 @@ func TestHelperProcess(t *testing.T) {
 
 	cmd, subcmd, subsubcmd, args := args[0], args[1], args[2], args[3:]
 
-	if cmd != "/hab/bin/hab" {
-		fmt.Fprintf(os.Stderr, "expected '/hab/bin/hab', but %v\n", cmd)
+	if cmd != "/opt/hab/bin/hab" {
+		fmt.Fprintf(os.Stderr, "expected '/opt/hab/bin/hab', but %v\n", cmd)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
`/hab` directory has been changed to `/opt/hab` and `/hab/bin/hab` should be `/opt/hab/bin/hab`
https://github.com/screwdriver-cd/executor-k8s/commit/a2ea4d9d46e8ae135f8fdd7cbb3dfe5efa53832d#diff-052e9d6ff615a6db485c488784e1f398R43