### PR TITLE
fix: hab path

### DIFF
--- a/executor/habitat.go
+++ b/executor/habitat.go
@@ -10,7 +10,7 @@ import (
 	"github.com/screwdriver-cd/sd-cmd/util"
 )
 
-const habPath = "/opt/hab/bin/hab"
+const habPath = "/opt/sd/bin/hab"
 
 // Habitat is the Habitat Executor struct
 type Habitat struct {

--- a/executor/habitat_test.go
+++ b/executor/habitat_test.go
@@ -130,8 +130,8 @@ func TestHelperProcess(t *testing.T) {
 
 	cmd, subcmd, subsubcmd, args := args[0], args[1], args[2], args[3:]
 
-	if cmd != "/opt/hab/bin/hab" {
-		fmt.Fprintf(os.Stderr, "expected '/opt/hab/bin/hab', but %v\n", cmd)
+	if cmd != "/opt/sd/bin/hab" {
+		fmt.Fprintf(os.Stderr, "expected '/opt/sd/bin/hab', but %v\n", cmd)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
`/opt/hab/bin/hab` doesn't exist
Should be [`/opt/sd/bin/hab`](https://github.com/screwdriver-cd/launcher/blob/df18ce624edea9328fe9ef9ba950fc628d7190b9/Dockerfile#L76)