### PR TITLE
fix: write date to stdin pipe asynchronously.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ artifacts/
 .DS_STORE
 .*.swp
 sd-cmd
+.sd/
 
 # Generated while deploying
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -75,6 +75,7 @@ func execCommand(path string, args []string) (err error) {
 		}
 		go func() {
 			defer stdin.Close()
+			defer close(errChan)
 			// Note: we must use goroutine,
 			// because when writing data exceeding pipe capacity this line is blocked until reading it.
 			_, err = io.Copy(stdin, os.Stdin)
@@ -97,7 +98,7 @@ func execCommand(path string, args []string) (err error) {
 
 	lgr.Debug.Println("mmmmmm FINISH COMMAND OUTPUT mmmmmm")
 
-	// Note: closed channel returns nil
+	// Note: closed channel returns buffered message or a zero value if it is empty.
 	stdinErr := <-errChan
 	if stdinErr != nil {
 		return stdinErr

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -96,14 +96,14 @@ func execCommand(path string, args []string) (err error) {
 	err = cmd.Run()
 
 	lgr.Debug.Println("mmmmmm FINISH COMMAND OUTPUT mmmmmm")
-	if err != nil {
-		lgr.Debug.Printf("failed to exec command: %v", err)
-		return
-	}
 
 	// Note: closed channel returns nil
-	err = <-errChan
+	stdinErr := <-errChan
+	if stdinErr != nil {
+		return stdinErr
+	}
 	if err != nil {
+		lgr.Debug.Printf("failed to exec command: %v", err)
 		return
 	}
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"golang.org/x/crypto/ssh/terminal"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -74,19 +73,14 @@ func execCommand(path string, args []string) (err error) {
 			lgr.Debug.Printf("failed to open StdinPipe: %v", err)
 			return err
 		}
-		b, err := ioutil.ReadAll(os.Stdin)
-		if err != nil {
-			lgr.Debug.Printf("failed to read Stdin: %v", err)
-			return err
-		}
 		go func() {
 			defer stdin.Close()
 			// Note: we must use goroutine,
 			// because when writing data exceeding pipe capacity this line is blocked until reading it.
-			_, err = io.WriteString(stdin, string(b))
+			_, err = io.Copy(stdin, os.Stdin)
 			errChan <- err
 			if err != nil {
-				lgr.Debug.Printf("failed to write StdinPipe: %v", err)
+				lgr.Debug.Printf("failed to copy piped command stdin from os.Stdin: %v", err)
 			}
 		}()
 	} else {


### PR DESCRIPTION
## Context

Currently when writing data exceeding pipe capacity to the piped stdin its writing is blocked until reading it.

## Objective

This PR makes its writing asynchronous by the goroutine.
I will add a functional test instead of an unit test later.

## References

- https://golang.org/pkg/os/exec/#Cmd.StdinPipe

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
