### PR TITLE
feat(2399): Add removeTag command

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -99,6 +99,10 @@ func (d *dummySDAPI) TagCommand(spec *util.CommandSpec, targetVersion, tag strin
 	return nil, nil
 }
 
+func (d *dummySDAPI) RemoveTagCommand(spec *util.CommandSpec, tag string) (*util.TagResponse, error) {
+	return nil, nil
+}
+
 func newDummySDAPI(spec *util.CommandSpec, err error) api.API {
 	d := &dummySDAPI{
 		spec: spec,

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -50,6 +50,10 @@ func (d *dummySDAPI) ValidateCommand(yamlString string) (*util.ValidateResponse,
 	return nil, nil
 }
 
+func (d *dummySDAPI) RemoveTagCommand(spec *util.CommandSpec, tag string) (*util.TagResponse, error) {
+	return nil, nil
+}
+
 func (d *dummySDAPI) TagCommand(spec *util.CommandSpec, targetVersion, tag string) (*util.TagResponse, error) {
 	return &util.TagResponse{
 		Namespace: dummyNameSpace,

--- a/removeTag/removeTag.go
+++ b/removeTag/removeTag.go
@@ -1,0 +1,67 @@
+package removeTag
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/screwdriver-cd/sd-cmd/screwdriver/api"
+	"github.com/screwdriver-cd/sd-cmd/util"
+)
+
+// RemoveTag is a type to remove tags from commands
+type RemoveTag struct {
+	smallSpec     *util.CommandSpec
+	sdAPI         api.API
+	tag           string
+}
+
+// New generates new removeTag.
+// args is expected as ["namespace/name", "tag"]
+func New(api api.API, args []string) (p *RemoveTag, err error) {
+	if len(args) != 2 {
+		return nil, fmt.Errorf("parameters are not enough")
+	}
+	tag := args[1]
+
+	commandName := strings.Split(args[0], "/") // namespace/name
+	if len(commandName) != 2 {
+		return nil, fmt.Errorf("%v is invalid command name", args[0])
+	}
+
+	if !util.ValidateTagName(tag) {
+		return nil, fmt.Errorf("%v is invalid tag name", tag)
+	}
+
+	smallSpec := &util.CommandSpec{
+		Namespace: commandName[0],
+		Name:      commandName[1],
+		Version:   tag,
+	}
+
+	p = &RemoveTag{
+		smallSpec:     smallSpec,
+		sdAPI:         api,
+		tag:           tag,
+	}
+
+	return
+}
+
+// Run executes tag command API
+func (p *RemoveTag) Run() (err error) {
+	_, err = p.sdAPI.GetCommand(p.smallSpec)
+	if err != nil {
+		fmt.Printf("%v does not exist yet\n", p.tag)
+		err = nil
+		return
+	}
+
+	res, err := p.sdAPI.RemoveTagCommand(p.smallSpec, p.tag)
+	if err != nil {
+		fmt.Println("Remove tag is aborted")
+		return
+	}
+
+	fmt.Printf("Removing %v from %v\n", res.Tag, res.Version)
+	return
+}

--- a/sd-cmd.go
+++ b/sd-cmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/screwdriver-cd/sd-cmd/logger"
 	"github.com/screwdriver-cd/sd-cmd/promoter"
 	"github.com/screwdriver-cd/sd-cmd/publisher"
+	"github.com/screwdriver-cd/sd-cmd/removeTag"
 	"github.com/screwdriver-cd/sd-cmd/screwdriver/api"
 	"github.com/screwdriver-cd/sd-cmd/validator"
 )
@@ -93,8 +94,16 @@ func runValidator(sdAPI api.API, args []string) error {
 	return val.Run()
 }
 
+func runRemoveTag(sdAPI api.API, args []string) error {
+	val, err := removeTag.New(sdAPI, args)
+	if err != nil {
+		return fmt.Errorf("Fail to get validator: %v", err)
+	}
+	return val.Run()
+}
+
 func runCommand(sdAPI api.API, args []string) error {
-	if len(os.Args) < minArgLength {
+	if len(args) < minArgLength {
 		return fmt.Errorf("The number of arguments is not enough")
 	}
 
@@ -107,6 +116,8 @@ func runCommand(sdAPI api.API, args []string) error {
 		return runPromoter(sdAPI, args[2:])
 	case "validate":
 		return runValidator(sdAPI, args[2:])
+	case "removeTag":
+		return runRemoveTag(sdAPI, args[2:])
 	default:
 		return runExecutor(sdAPI, args)
 	}

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -32,6 +32,10 @@ func (d *dummySDAPIValidator) TagCommand(spec *util.CommandSpec, targetVersion, 
 	return nil, nil
 }
 
+func (d *dummySDAPIValidator) RemoveTagCommand(spec *util.CommandSpec, tag string) (*util.TagResponse, error) {
+	return nil, nil
+}
+
 func TestNew(t *testing.T) {
 	// success
 	testDataPath := "../testdata/yaml/sd-command.yaml"


### PR DESCRIPTION
## Context
We want a tag remove command on sd-cmd cli.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We implement a tag remove command. We add `removeTag/` and add `RemoveTagCommand` to `screwdriver/api/api.go` for that.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2399
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
