### PR TITLE
feat(2467): [Breaking Change] Change log behave not to output log to file by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ go build -a -o sd-cmd
 
 ### Execute
 ```bash
-$ sd-cmd [flags] exec namespace/name@version [arguments]
+$ sd-cmd exec [flags] namespace/name@version [arguments]
 
 # usage
 # Flags:

--- a/README.md
+++ b/README.md
@@ -14,8 +14,18 @@ $ go build -a -o sd-cmd
 
 ### Execute
 ```bash
-$ sd-cmd exec namespace/name@version [arguments]
+$ sd-cmd [flags] exec namespace/name@version [arguments]
+
+# usage
+# Flags:
+#   -debug, --debug    output debug logs to a file
 ```
+
+#### Debug mode
+In debug mode, the debug log can be output to a file.  
+It can be used in one of the following ways.
+- Use `-debug` of `--debug` option
+- Set `SD_CMD_DEBUG_LOG` environment variable to `true`
 
 ## Testing
 ```bash

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"strconv"
 )
 
 var (
@@ -17,6 +18,8 @@ var (
 	SDArtifactsDir string
 	// BaseCommandPath is path of installing binary command
 	BaseCommandPath = "/opt/sd/commands/"
+	// DEBUG is flag of debug option
+	DEBUG bool
 )
 
 // LoadConfig sets config data
@@ -31,4 +34,5 @@ func LoadConfig() {
 	if len(os.Getenv("SD_BASE_COMMAND_PATH")) != 0 {
 		BaseCommandPath = os.Getenv("SD_BASE_COMMAND_PATH")
 	}
+	DEBUG, _ = strconv.ParseBool(os.Getenv("SD_CMD_DEBUG_LOG"))
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,7 +2,10 @@ package config
 
 import (
 	"os"
+	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -15,6 +18,7 @@ const (
 	dummyStoreURL       = "dummy-store/"
 	dummySDArtifactsDir = "dummy/sd/Artifacts/"
 	dummyCustomCmdPath  = "/opt/sd/commands/"
+	dummyDebug          = "true"
 )
 
 func setEnv(key, value string) {
@@ -30,6 +34,8 @@ func setup() {
 	setEnv("SD_TOKEN", dummyToken)
 	setEnv("SD_STORE_URL", dummyStoreURL)
 	setEnv("SD_ARTIFACTS_DIR", dummySDArtifactsDir)
+	setEnv("SD_BASE_COMMAND_PATH", dummyCustomCmdPath)
+	setEnv("SD_CMD_DEBUG_LOG", dummyDebug)
 }
 
 func teardown() {
@@ -40,39 +46,20 @@ func teardown() {
 
 func TestLoadConfig(t *testing.T) {
 	LoadConfig()
-	if SDAPIURL != dummyAPIURL {
-		t.Errorf("SDAPIURL=%q, want %q", SDAPIURL, dummyAPIURL)
-	}
-	if SDToken != dummyToken {
-		t.Errorf("SDToken=%q, want %q", SDToken, dummyToken)
-	}
-	if SDStoreURL != dummyStoreURL {
-		t.Errorf("SDStoreURL=%q, want %q", SDStoreURL, dummyStoreURL)
-	}
-	if SDArtifactsDir != dummySDArtifactsDir {
-		t.Errorf("SDArtifactsDir=%q, want %q", SDArtifactsDir, dummySDArtifactsDir)
-	}
-	wantBaseCommandPath := os.Getenv("SD_BASE_COMMAND_PATH")
-	if wantBaseCommandPath == "" {
-		wantBaseCommandPath = dummyCustomCmdPath
-	}
-	if BaseCommandPath != wantBaseCommandPath {
-		t.Errorf("BaseCommandPath=%q, want %s", BaseCommandPath, wantBaseCommandPath)
-	}
+	assert.Equal(t, dummyAPIURL, SDAPIURL)
+	assert.Equal(t, dummyToken, SDToken)
+	assert.Equal(t, dummyStoreURL, SDStoreURL)
+	assert.Equal(t, dummySDArtifactsDir, SDArtifactsDir)
+	assert.Equal(t, dummyCustomCmdPath, BaseCommandPath)
+	wantDebug, _ := strconv.ParseBool(dummyDebug)
+	assert.Equal(t, wantDebug, DEBUG)
 
 	// check unset env
 	os.Unsetenv("SD_API_URL")
+	os.Unsetenv("SD_CMD_DEBUG_LOG")
 	LoadConfig()
-	if SDAPIURL != "" {
-		t.Errorf("SDAPIURL=%q, want blank", SDAPIURL)
-	}
-
-	// set SD_BASE_COMMAND_PATH
-	setEnv("SD_BASE_COMMAND_PATH", dummyCustomCmdPath)
-	LoadConfig()
-	if BaseCommandPath != dummyCustomCmdPath {
-		t.Errorf("BaseCommandPath=%q, want %q", BaseCommandPath, dummyCustomCmdPath)
-	}
+	assert.Equal(t, "", SDAPIURL)
+	assert.Equal(t, false, DEBUG)
 }
 
 func TestMain(m *testing.M) {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1,19 +1,15 @@
 package executor
 
 import (
-	"fmt"
 	"io"
 	"log"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"syscall"
-	"time"
 
 	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/pkg/errors"
-	"github.com/screwdriver-cd/sd-cmd/config"
 	"github.com/screwdriver-cd/sd-cmd/logger"
 	"github.com/screwdriver-cd/sd-cmd/screwdriver/api"
 	"github.com/screwdriver-cd/sd-cmd/util"
@@ -30,9 +26,10 @@ type Executor interface {
 }
 
 func prepareLog(smallSpec *util.CommandSpec) (err error) {
-	dirPath := filepath.Join(config.SDArtifactsDir, ".sd", "commands")
-	filename := fmt.Sprintf("%v-%v-%v.log", time.Now().Unix(), smallSpec.Namespace, smallSpec.Name)
-	lgr, err = logger.New(logger.OutputToFileWithCreate(dirPath, filename), logger.DebugFlag(log.LstdFlags), logger.OutputDebugLog(false))
+	// dirPath := filepath.Join(config.SDArtifactsDir, ".sd", "commands")
+	// filename := fmt.Sprintf("%v-%v-%v.log", time.Now().Unix(), smallSpec.Namespace, smallSpec.Name)
+	// lgr, err = logger.New(logger.OutputToFileWithCreate(dirPath, filename), logger.DebugFlag(log.LstdFlags), logger.OutputDebugLog(false))
+	lgr, err = logger.New(logger.DebugFlag(log.LstdFlags), logger.OutputDebugLog(false))
 	return
 }
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -2,7 +2,6 @@ package executor
 
 import (
 	"fmt"
-	"golang.org/x/crypto/ssh/terminal"
 	"io"
 	"log"
 	"os"
@@ -10,6 +9,8 @@ import (
 	"path/filepath"
 	"syscall"
 	"time"
+
+	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/pkg/errors"
 	"github.com/screwdriver-cd/sd-cmd/config"
@@ -31,7 +32,7 @@ type Executor interface {
 func prepareLog(smallSpec *util.CommandSpec) (err error) {
 	dirPath := filepath.Join(config.SDArtifactsDir, ".sd", "commands")
 	filename := fmt.Sprintf("%v-%v-%v.log", time.Now().Unix(), smallSpec.Namespace, smallSpec.Name)
-	lgr, err = logger.New(dirPath, filename, log.LstdFlags, false)
+	lgr, err = logger.New(logger.OutputToFileWithCreate(dirPath, filename), logger.DebugFlag(log.LstdFlags), logger.OutputDebugLog(false))
 	return
 }
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -37,7 +37,7 @@ type Executor interface {
 func prepareLog(smallSpec *util.CommandSpec, isDebug bool) (err error) {
 	var file io.WriteCloser
 
-	if isDebug {
+	if isDebug || config.DEBUG {
 		dirPath := filepath.Join(config.SDArtifactsDir, ".sd", "commands")
 		filename := fmt.Sprintf("%v-%v-%v.log", time.Now().Unix(), smallSpec.Namespace, smallSpec.Name)
 		file, err = createLogFile(dirPath, filename)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -36,7 +35,7 @@ type Executor interface {
 }
 
 func prepareLog(smallSpec *util.CommandSpec, hasOutputLogFile bool) (err error) {
-	options := []logger.LogOption{logger.OptDebugFlag(log.LstdFlags), logger.OptOutputDebugLog(false)}
+	options := []logger.LogOption{logger.OptOutputDebugLog(false)}
 	if hasOutputLogFile {
 		dirPath := filepath.Join(config.SDArtifactsDir, ".sd", "commands")
 		filename := fmt.Sprintf("%v-%v-%v.log", time.Now().Unix(), smallSpec.Namespace, smallSpec.Name)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -23,7 +23,10 @@ import (
 var (
 	command = exec.Command
 	lgr     *logger.Logger
+)
 
+// exec subcommand flags
+var (
 	hasOutputLogFile = false
 )
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -161,7 +161,5 @@ func execCommand(path string, args []string) (err error) {
 
 // CleanUp close file you use.
 func CleanUp() {
-	if lgr.File() != nil {
-		lgr.File().Close()
-	}
+	lgr.Close()
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -26,7 +26,7 @@ var (
 
 // exec subcommand flags
 var (
-	hasOutputLogFile = false
+	isDebug = false
 )
 
 // Executor is a Executor endpoint
@@ -34,12 +34,12 @@ type Executor interface {
 	Run() error
 }
 
-func prepareLog(smallSpec *util.CommandSpec, hasOutputLogFile bool) (err error) {
-	options := []logger.LogOption{logger.OptOutputDebugLog(false)}
-	if hasOutputLogFile {
+func prepareLog(smallSpec *util.CommandSpec, isDebug bool) (err error) {
+	options := []logger.LogOption{}
+	if isDebug {
 		dirPath := filepath.Join(config.SDArtifactsDir, ".sd", "commands")
 		filename := fmt.Sprintf("%v-%v-%v.log", time.Now().Unix(), smallSpec.Namespace, smallSpec.Name)
-		options = append(options, logger.OptOutputToFileWithCreate(dirPath, filename))
+		options = append(options, logger.OptDebugWithCreate(dirPath, filename))
 	}
 	lgr, err = logger.New(options...)
 	return
@@ -47,7 +47,7 @@ func prepareLog(smallSpec *util.CommandSpec, hasOutputLogFile bool) (err error) 
 
 func parseExecSubCommands(args []string) ([]string, error) {
 	f := flag.NewFlagSet("exec", flag.ContinueOnError)
-	f.BoolVar(&hasOutputLogFile, "log-file", false, "output log to file")
+	f.BoolVar(&isDebug, "debug", false, "output log to file")
 	err := f.Parse(args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse exec args: %w", err)
@@ -67,7 +67,7 @@ func New(sdAPI api.API, args []string) (Executor, error) {
 		return nil, err
 	}
 
-	err = prepareLog(smallSpec, hasOutputLogFile)
+	err = prepareLog(smallSpec, isDebug)
 	if err != nil {
 		return nil, err
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -35,13 +35,17 @@ type Executor interface {
 }
 
 func prepareLog(smallSpec *util.CommandSpec, isDebug bool) (err error) {
-	options := []logger.LogOption{}
+	var file io.WriteCloser
+
 	if isDebug {
 		dirPath := filepath.Join(config.SDArtifactsDir, ".sd", "commands")
 		filename := fmt.Sprintf("%v-%v-%v.log", time.Now().Unix(), smallSpec.Namespace, smallSpec.Name)
-		options = append(options, logger.OptDebugWithCreate(dirPath, filename))
+		file, err = createLogFile(dirPath, filename)
+		if err != nil {
+			return err
+		}
 	}
-	lgr, err = logger.New(options...)
+	lgr, err = logger.New(file)
 	return
 }
 
@@ -53,6 +57,23 @@ func parseExecSubCommands(args []string) ([]string, error) {
 		return nil, fmt.Errorf("failed to parse exec args: %w", err)
 	}
 	return f.Args(), nil
+}
+
+func createLogFile(dirPath, filename string) (io.WriteCloser, error) {
+	if filename == "" {
+		filename = fmt.Sprintf("%v.log", time.Now().Unix())
+	}
+	err := os.MkdirAll(dirPath, 0777)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create logging directory: %v", err)
+	}
+
+	filePath := filepath.Join(dirPath, filename)
+	file, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create logging file: %v", err)
+	}
+	return file, nil
 }
 
 // New returns each format type of Executor
@@ -136,4 +157,11 @@ func execCommand(path string, args []string) (err error) {
 	state := cmd.ProcessState
 	lgr.Debug.Printf("System Time: %v, User Time: %v\n", state.SystemTime(), state.UserTime())
 	return
+}
+
+// CleanUp close file you use.
+func CleanUp() {
+	if lgr.File() != nil {
+		lgr.File().Close()
+	}
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -24,7 +24,7 @@ var (
 	command = exec.Command
 	lgr     *logger.Logger
 
-	outputLogFile = false
+	hasOutputLogFile = false
 )
 
 // Executor is a Executor endpoint
@@ -32,9 +32,9 @@ type Executor interface {
 	Run() error
 }
 
-func prepareLog(smallSpec *util.CommandSpec, outputLogFile bool) (err error) {
+func prepareLog(smallSpec *util.CommandSpec, hasOutputLogFile bool) (err error) {
 	options := []logger.LogOption{logger.DebugFlag(log.LstdFlags), logger.OutputDebugLog(false)}
-	if outputLogFile {
+	if hasOutputLogFile {
 		dirPath := filepath.Join(config.SDArtifactsDir, ".sd", "commands")
 		filename := fmt.Sprintf("%v-%v-%v.log", time.Now().Unix(), smallSpec.Namespace, smallSpec.Name)
 		options = append(options, logger.OutputToFileWithCreate(dirPath, filename))
@@ -45,7 +45,7 @@ func prepareLog(smallSpec *util.CommandSpec, outputLogFile bool) (err error) {
 
 func parseExecSubCommands(args []string) ([]string, error) {
 	f := flag.NewFlagSet("exec", flag.ContinueOnError)
-	f.BoolVar(&outputLogFile, "log-file", false, "output log to file")
+	f.BoolVar(&hasOutputLogFile, "log-file", false, "output log to file")
 	err := f.Parse(args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse exec args: %w", err)
@@ -65,7 +65,7 @@ func New(sdAPI api.API, args []string) (Executor, error) {
 		return nil, err
 	}
 
-	err = prepareLog(smallSpec, outputLogFile)
+	err = prepareLog(smallSpec, hasOutputLogFile)
 	if err != nil {
 		return nil, err
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -36,11 +36,11 @@ type Executor interface {
 }
 
 func prepareLog(smallSpec *util.CommandSpec, hasOutputLogFile bool) (err error) {
-	options := []logger.LogOption{logger.DebugFlag(log.LstdFlags), logger.OutputDebugLog(false)}
+	options := []logger.LogOption{logger.OptDebugFlag(log.LstdFlags), logger.OptOutputDebugLog(false)}
 	if hasOutputLogFile {
 		dirPath := filepath.Join(config.SDArtifactsDir, ".sd", "commands")
 		filename := fmt.Sprintf("%v-%v-%v.log", time.Now().Unix(), smallSpec.Namespace, smallSpec.Name)
-		options = append(options, logger.OutputToFileWithCreate(dirPath, filename))
+		options = append(options, logger.OptOutputToFileWithCreate(dirPath, filename))
 	}
 	lgr, err = logger.New(options...)
 	return

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -69,7 +69,7 @@ func setup() {
 	// setting lgr for logging
 	logBuffer = bytes.NewBuffer([]byte{})
 	d := &dummyLogFile{buffer: logBuffer}
-	l, _ := logger.New(logger.OptDebug(d), logger.OptDebugFlag(0))
+	l, _ := logger.New(logger.OptDebug(d))
 	lgr = l
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -171,42 +171,64 @@ func dummyCommandSpec(format string) (spec *util.CommandSpec) {
 
 func TestNew(t *testing.T) {
 	successCases := []struct {
-		name      string
-		spec      *util.CommandSpec
-		args      []string
-		isLogFile bool
+		name         string
+		spec         *util.CommandSpec
+		args         []string
+		debugFromEnv bool
+		isLogFile    bool
 	}{
 		{
-			name:      "binary format succes with no logging with file",
-			spec:      dummyCommandSpec(binaryFormat),
-			args:      []string{"ns/cmd@ver"},
-			isLogFile: false,
+			name:         "binary format succes with no logging with file",
+			spec:         dummyCommandSpec(binaryFormat),
+			args:         []string{"ns/cmd@ver"},
+			debugFromEnv: false,
+			isLogFile:    false,
 		},
 		{
-			name:      "binary format success with no logging with file",
-			spec:      dummyCommandSpec(habitatFormat),
-			args:      []string{"exec", "ns/cmd@ver"},
-			isLogFile: false,
+			name:         "binary format success with no logging with file",
+			spec:         dummyCommandSpec(habitatFormat),
+			args:         []string{"exec", "ns/cmd@ver"},
+			debugFromEnv: false,
+			isLogFile:    false,
 		},
 		{
-			name:      "should output log file",
-			spec:      dummyCommandSpec(binaryFormat),
-			args:      []string{"--debug", "ns/cmd@ver"},
-			isLogFile: true,
+			name:         "should output log file by option",
+			spec:         dummyCommandSpec(binaryFormat),
+			args:         []string{"--debug", "ns/cmd@ver"},
+			debugFromEnv: false,
+			isLogFile:    true,
 		},
 		{
-			name:      "should not output log file",
-			spec:      dummyCommandSpec(binaryFormat),
-			args:      []string{"ns/cmd@ver", "--debug"},
-			isLogFile: false,
+			name:         "should output log file by env",
+			spec:         dummyCommandSpec(binaryFormat),
+			args:         []string{"ns/cmd@ver"},
+			debugFromEnv: true,
+			isLogFile:    true,
+		},
+		{
+			name:         "should output log file by option and env",
+			spec:         dummyCommandSpec(binaryFormat),
+			args:         []string{"--debug", "ns/cmd@ver"},
+			debugFromEnv: true,
+			isLogFile:    true,
+		},
+		{
+			name:         "should not output log file",
+			spec:         dummyCommandSpec(binaryFormat),
+			args:         []string{"ns/cmd@ver", "--debug"},
+			debugFromEnv: false,
+			isLogFile:    false,
 		},
 	}
 	for _, tt := range successCases {
 		t.Run(tt.name, func(t *testing.T) {
 			l := lgr
+			d := config.DEBUG
 			defer func() {
 				lgr = l
+				config.DEBUG = d
 			}()
+			config.DEBUG = tt.debugFromEnv
 			sdapi := newDummySDAPI(tt.spec, nil)
 			executor, err := New(sdapi, tt.args)
 			assert.Nil(t, err)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -48,10 +48,15 @@ var (
 )
 
 type dummyLogFile struct {
-	buffer *bytes.Buffer
+	buffer   *bytes.Buffer
+	isClosed bool
 }
 
-func (d *dummyLogFile) Close() error { return nil }
+func (d *dummyLogFile) Close() error {
+	d.isClosed = true
+	return nil
+}
+
 func (d *dummyLogFile) Write(p []byte) (n int, err error) {
 	return d.buffer.Write(p)
 }
@@ -244,6 +249,18 @@ func TestNew(t *testing.T) {
 			assert.NotNil(t, err)
 		})
 	}
+}
+
+func TestCleanUp(t *testing.T) {
+	l := lgr
+	defer func() {
+		lgr = l
+	}()
+
+	file := &dummyLogFile{buffer: bytes.NewBuffer([]byte{})}
+	lgr, _ = logger.New(file)
+	CleanUp()
+	assert.Equal(t, true, file.isClosed)
 }
 
 func TestMain(m *testing.M) {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -164,8 +164,6 @@ func dummyCommandSpec(format string) (spec *util.CommandSpec) {
 	return spec
 }
 
-// TODO should not output log file without --log-file flag
-// TODO should be output log file with --log-file flag(sd-cmd exec --log-file aa@stable)
 func TestNew(t *testing.T) {
 	successCases := []struct {
 		name      string

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -185,6 +185,18 @@ func TestNew(t *testing.T) {
 			args:      []string{"exec", "ns/cmd@ver"},
 			isLogFile: false,
 		},
+		{
+			name:      "should output log file",
+			spec:      dummyCommandSpec(binaryFormat),
+			args:      []string{"--log-file", "ns/cmd@ver"},
+			isLogFile: true,
+		},
+		{
+			name:      "should not output log file",
+			spec:      dummyCommandSpec(binaryFormat),
+			args:      []string{"ns/cmd@ver", "--log-file"},
+			isLogFile: false,
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -197,9 +209,12 @@ func TestNew(t *testing.T) {
 			assert.Nil(t, err)
 			_, ok := executor.(Executor)
 			assert.True(t, ok)
-			if !tt.isLogFile {
+			if tt.isLogFile {
+				assert.NotNil(t, lgr.File())
+			} else {
 				assert.Nil(t, lgr.File())
 			}
+
 		})
 	}
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -214,7 +214,6 @@ func TestNew(t *testing.T) {
 			} else {
 				assert.Nil(t, lgr.File())
 			}
-
 		})
 	}
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -66,10 +66,9 @@ func setup() {
 	invalidShell = string(b)
 
 	// setting lgr for logging
-	l := new(logger.Logger)
 	logBuffer = bytes.NewBuffer([]byte{})
 	d := &dummyLogFile{buffer: logBuffer}
-	l.SetInfos(d, 0, true)
+	l, _ := logger.New(logger.OutputToFile(d), logger.DebugFlag(0), logger.OutputDebugLog(true))
 	lgr = l
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -69,7 +69,7 @@ func setup() {
 	// setting lgr for logging
 	logBuffer = bytes.NewBuffer([]byte{})
 	d := &dummyLogFile{buffer: logBuffer}
-	l, _ := logger.New(logger.OptDebug(d))
+	l, _ := logger.New(d)
 	lgr = l
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -69,7 +69,7 @@ func setup() {
 	// setting lgr for logging
 	logBuffer = bytes.NewBuffer([]byte{})
 	d := &dummyLogFile{buffer: logBuffer}
-	l, _ := logger.New(logger.OutputToFile(d), logger.DebugFlag(0), logger.OutputDebugLog(true))
+	l, _ := logger.New(logger.OptOutputToFile(d), logger.OptDebugFlag(0), logger.OptOutputDebugLog(true))
 	lgr = l
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -69,7 +69,7 @@ func setup() {
 	// setting lgr for logging
 	logBuffer = bytes.NewBuffer([]byte{})
 	d := &dummyLogFile{buffer: logBuffer}
-	l, _ := logger.New(logger.OptOutputToFile(d), logger.OptDebugFlag(0), logger.OptOutputDebugLog(true))
+	l, _ := logger.New(logger.OptDebug(d), logger.OptDebugFlag(0))
 	lgr = l
 }
 
@@ -186,13 +186,13 @@ func TestNew(t *testing.T) {
 		{
 			name:      "should output log file",
 			spec:      dummyCommandSpec(binaryFormat),
-			args:      []string{"--log-file", "ns/cmd@ver"},
+			args:      []string{"--debug", "ns/cmd@ver"},
 			isLogFile: true,
 		},
 		{
 			name:      "should not output log file",
 			spec:      dummyCommandSpec(binaryFormat),
-			args:      []string{"ns/cmd@ver", "--log-file"},
+			args:      []string{"ns/cmd@ver", "--debug"},
 			isLogFile: false,
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/crypto v0.0.0-20200214034016-1d94cc7ab1c6
+	golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-retryablehttp v0.6.6 h1:HJunrbHTDDbBb/ay4kxa1n+dLmttUlnP3V9oNE4hmsM=
 github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
@@ -18,7 +19,10 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 h1:bNEHhJCnrwMKNMmOx3yAynp5vs5/gRy+XWFtZFu7NBM=
+golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -22,6 +22,13 @@ func (l *Logger) File() io.WriteCloser {
 	return l.file
 }
 
+// Close finish log file safely
+func (l *Logger) Close() {
+	if l.file != nil {
+		l.file.Close()
+	}
+}
+
 // New returns logger object
 func New(file io.WriteCloser) (*Logger, error) {
 	lgr := new(Logger)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -59,7 +59,7 @@ func New(options ...LogOption) (*Logger, error) {
 		}
 	}
 
-	lgr.SetInfos(lgr.file, lgr.debugFlag, lgr.isOutputDebugLog)
+	lgr.setInfos(lgr.file, lgr.debugFlag, lgr.isOutputDebugLog)
 	return lgr, nil
 }
 
@@ -83,7 +83,7 @@ func CreateLogFile(dirPath, filename string) (io.WriteCloser, error) {
 }
 
 // SetInfos set logger information from arguments
-func (l *Logger) SetInfos(file io.WriteCloser, flag int, debug bool) {
+func (l *Logger) setInfos(file io.WriteCloser, flag int, debug bool) {
 	l.file = file
 	if debug {
 		l.Debug = log.New(io.MultiWriter(os.Stderr, file), "", flag)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -11,6 +11,7 @@ import (
 	"time"
 )
 
+// LogOption enable to customize Logger
 type LogOption func(l *Logger) error
 
 var loggingFiles []io.WriteCloser
@@ -25,18 +26,22 @@ type Logger struct {
 	Error             *log.Logger // Error is always debug file and stderr with LstdFlags flag.
 }
 
+// DebugFlag return current log debugFlag status
 func (l *Logger) DebugFlag() int {
 	return l.debugFlag
 }
 
-func (l *Logger) ErrorFLag() int {
+// ErrorFlag return current log errorFlag status
+func (l *Logger) ErrorFlag() int {
 	return l.errorFlag
 }
 
+// File return current log output file. If the file = nil, logger does not output log to file
 func (l *Logger) File() io.WriteCloser {
 	return l.file
 }
 
+// OutputToFileWithCreate create file for output log
 func OutputToFileWithCreate(dir, filename string) LogOption {
 	return func(l *Logger) error {
 		file, err := createLogFile(dir, filename)
@@ -48,6 +53,7 @@ func OutputToFileWithCreate(dir, filename string) LogOption {
 	}
 }
 
+// OutputToFile output log to the file
 func OutputToFile(file io.WriteCloser) LogOption {
 	return func(l *Logger) error {
 		l.file = file
@@ -55,6 +61,7 @@ func OutputToFile(file io.WriteCloser) LogOption {
 	}
 }
 
+// DebugFlag set Logger.Debug flag
 func DebugFlag(flag int) LogOption {
 	return func(l *Logger) error {
 		l.debugFlag = flag
@@ -62,6 +69,7 @@ func DebugFlag(flag int) LogOption {
 	}
 }
 
+// ErrorFlag set Logger.Error flag
 func ErrorFlag(flag int) LogOption {
 	return func(l *Logger) error {
 		l.errorFlag = flag
@@ -69,6 +77,7 @@ func ErrorFlag(flag int) LogOption {
 	}
 }
 
+// OutputDebugLog output debug log
 func OutputDebugLog(output bool) LogOption {
 	return func(l *Logger) error {
 		l.hasOutputDebugLog = output

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -20,7 +20,6 @@ var loggingFiles []io.WriteCloser
 type Logger struct {
 	debugFlag int
 	errorFlag int
-	isDebug   bool
 	file      io.WriteCloser
 	Debug     *log.Logger // Debug is for debug log. You can set log flag. Also you can choose log stderr or not
 	Error     *log.Logger // Error is always debug file and stderr with LstdFlags flag.
@@ -60,7 +59,6 @@ func OptErrorFlag(flag int) LogOption {
 // OptDebug output debug log
 func OptDebug(file io.WriteCloser) LogOption {
 	return func(l *Logger) error {
-		l.isDebug = true
 		l.file = file
 		return nil
 	}
@@ -114,7 +112,7 @@ func createLogFile(dirPath, filename string) (io.WriteCloser, error) {
 }
 
 func (l *Logger) buildDebugLogger() {
-	if l.isDebug && l.file != nil {
+	if l.file != nil {
 		l.Debug = log.New(l.file, "", l.debugFlag)
 		return
 	}
@@ -122,7 +120,7 @@ func (l *Logger) buildDebugLogger() {
 }
 
 func (l *Logger) buildErrorLogger() {
-	if l.isDebug && l.file != nil {
+	if l.file != nil {
 		l.Error = log.New(io.MultiWriter(os.Stderr, l.file), "", l.errorFlag)
 		return
 	}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -89,6 +89,7 @@ func OptOutputDebugLog(output bool) LogOption {
 func New(options ...LogOption) (*Logger, error) {
 	lgr := new(Logger)
 	lgr.errorFlag = log.LstdFlags
+	lgr.debugFlag = log.LstdFlags
 
 	for _, o := range options {
 		err := o(lgr)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -25,6 +25,18 @@ type Logger struct {
 	Error            *log.Logger // Error is always debug file and stderr with LstdFlags flag.
 }
 
+func (l *Logger) DebugFlag() int {
+	return l.debugFlag
+}
+
+func (l *Logger) ErrorFLag() int {
+	return l.errorFlag
+}
+
+func (l *Logger) File() io.WriteCloser {
+	return l.file
+}
+
 func OutputToFileWithCreate(dir, filename string) LogOption {
 	return func(l *Logger) error {
 		file, err := createLogFile(dir, filename)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -25,7 +25,7 @@ type Logger struct {
 
 func OutputToFileWithCreate(dir, filename string) LogOption {
 	return func(l *Logger) error {
-		file, err := CreateLogFile(dir, filename)
+		file, err := createLogFile(dir, filename)
 		if err != nil {
 			return err
 		}
@@ -63,8 +63,7 @@ func New(options ...LogOption) (*Logger, error) {
 	return lgr, nil
 }
 
-// CreateLogFile create log file
-func CreateLogFile(dirPath, filename string) (io.WriteCloser, error) {
+func createLogFile(dirPath, filename string) (io.WriteCloser, error) {
 	if filename == "" {
 		filename = fmt.Sprintf("%v.log", time.Now().Unix())
 	}
@@ -82,7 +81,6 @@ func CreateLogFile(dirPath, filename string) (io.WriteCloser, error) {
 	return file, nil
 }
 
-// SetInfos set logger information from arguments
 func (l *Logger) setInfos(file io.WriteCloser, flag int, debug bool) {
 	l.file = file
 	if debug {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -25,35 +25,9 @@ type Logger struct {
 	Error     *log.Logger // Error is always debug file and stderr with LstdFlags flag.
 }
 
-// DebugFlag return current log debugFlag status
-func (l *Logger) DebugFlag() int {
-	return l.debugFlag
-}
-
-// ErrorFlag return current log errorFlag status
-func (l *Logger) ErrorFlag() int {
-	return l.errorFlag
-}
-
 // File return current log output file. If the file = nil, logger does not output log to file
 func (l *Logger) File() io.WriteCloser {
 	return l.file
-}
-
-// OptDebugFlag set Logger.Debug flag
-func OptDebugFlag(flag int) LogOption {
-	return func(l *Logger) error {
-		l.debugFlag = flag
-		return nil
-	}
-}
-
-// OptErrorFlag set Logger.Error flag
-func OptErrorFlag(flag int) LogOption {
-	return func(l *Logger) error {
-		l.errorFlag = flag
-		return nil
-	}
 }
 
 // OptDebug output debug log

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -34,6 +34,13 @@ func OutputToFileWithCreate(dir, filename string) LogOption {
 	}
 }
 
+func OutputToFile(file io.WriteCloser) LogOption {
+	return func(l *Logger) error {
+		l.file = file
+		return nil
+	}
+}
+
 func DebugFlag(flag int) LogOption {
 	return func(l *Logger) error {
 		l.debugFlag = flag
@@ -41,9 +48,9 @@ func DebugFlag(flag int) LogOption {
 	}
 }
 
-func OutputDebugLog() LogOption {
+func OutputDebugLog(output bool) LogOption {
 	return func(l *Logger) error {
-		l.isOutputDebugLog = true
+		l.isOutputDebugLog = output
 		return nil
 	}
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -41,8 +41,8 @@ func (l *Logger) File() io.WriteCloser {
 	return l.file
 }
 
-// OutputToFileWithCreate create file for output log
-func OutputToFileWithCreate(dir, filename string) LogOption {
+// OptOutputToFileWithCreate create file for output log
+func OptOutputToFileWithCreate(dir, filename string) LogOption {
 	return func(l *Logger) error {
 		file, err := createLogFile(dir, filename)
 		if err != nil {
@@ -53,32 +53,32 @@ func OutputToFileWithCreate(dir, filename string) LogOption {
 	}
 }
 
-// OutputToFile output log to the file
-func OutputToFile(file io.WriteCloser) LogOption {
+// OptOutputToFile output log to the file
+func OptOutputToFile(file io.WriteCloser) LogOption {
 	return func(l *Logger) error {
 		l.file = file
 		return nil
 	}
 }
 
-// DebugFlag set Logger.Debug flag
-func DebugFlag(flag int) LogOption {
+// OptDebugFlag set Logger.Debug flag
+func OptDebugFlag(flag int) LogOption {
 	return func(l *Logger) error {
 		l.debugFlag = flag
 		return nil
 	}
 }
 
-// ErrorFlag set Logger.Error flag
-func ErrorFlag(flag int) LogOption {
+// OptErrorFlag set Logger.Error flag
+func OptErrorFlag(flag int) LogOption {
 	return func(l *Logger) error {
 		l.errorFlag = flag
 		return nil
 	}
 }
 
-// OutputDebugLog output debug log
-func OutputDebugLog(output bool) LogOption {
+// OptOutputDebugLog output debug log
+func OptOutputDebugLog(output bool) LogOption {
 	return func(l *Logger) error {
 		l.hasOutputDebugLog = output
 		return nil

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -17,12 +17,12 @@ var loggingFiles []io.WriteCloser
 
 // Logger has information for logging
 type Logger struct {
-	debugFlag        int
-	errorFlag        int
-	isOutputDebugLog bool
-	file             io.WriteCloser
-	Debug            *log.Logger // Debug is for debug log. You can set log flag. Also you can choose log stderr or not
-	Error            *log.Logger // Error is always debug file and stderr with LstdFlags flag.
+	debugFlag         int
+	errorFlag         int
+	hasOutputDebugLog bool
+	file              io.WriteCloser
+	Debug             *log.Logger // Debug is for debug log. You can set log flag. Also you can choose log stderr or not
+	Error             *log.Logger // Error is always debug file and stderr with LstdFlags flag.
 }
 
 func (l *Logger) DebugFlag() int {
@@ -71,7 +71,7 @@ func ErrorFlag(flag int) LogOption {
 
 func OutputDebugLog(output bool) LogOption {
 	return func(l *Logger) error {
-		l.isOutputDebugLog = output
+		l.hasOutputDebugLog = output
 		return nil
 	}
 }
@@ -111,7 +111,7 @@ func createLogFile(dirPath, filename string) (io.WriteCloser, error) {
 }
 
 func (l *Logger) buildDebugLogger() {
-	if l.isOutputDebugLog {
+	if l.hasOutputDebugLog {
 		if l.file != nil {
 			l.Debug = log.New(io.MultiWriter(os.Stderr, l.file), "", l.debugFlag)
 			return

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -18,7 +18,7 @@ var loggingFiles []io.WriteCloser
 type Logger struct {
 	debugFlag        int
 	isOutputDebugLog bool
-	File             io.WriteCloser
+	file             io.WriteCloser
 	Debug            *log.Logger // Debug is for debug log. You can set log flag. Also you can choose log stderr or not
 	Error            *log.Logger // Error is always debug file and stderr with LstdFlags flag.
 }
@@ -29,7 +29,7 @@ func OutputToFileWithCreate(dir, filename string) LogOption {
 		if err != nil {
 			return err
 		}
-		l.File = file
+		l.file = file
 		return nil
 	}
 }
@@ -59,7 +59,7 @@ func New(options ...LogOption) (*Logger, error) {
 		}
 	}
 
-	lgr.SetInfos(lgr.File, lgr.debugFlag, lgr.isOutputDebugLog)
+	lgr.SetInfos(lgr.file, lgr.debugFlag, lgr.isOutputDebugLog)
 	return lgr, nil
 }
 
@@ -84,7 +84,7 @@ func CreateLogFile(dirPath, filename string) (io.WriteCloser, error) {
 
 // SetInfos set logger information from arguments
 func (l *Logger) SetInfos(file io.WriteCloser, flag int, debug bool) {
-	l.File = file
+	l.file = file
 	if debug {
 		l.Debug = log.New(io.MultiWriter(os.Stderr, file), "", flag)
 	} else {
@@ -95,8 +95,8 @@ func (l *Logger) SetInfos(file io.WriteCloser, flag int, debug bool) {
 
 // Close finish log file safely
 func (l *Logger) Close() {
-	if l.File != nil {
-		l.File.Close()
+	if l.file != nil {
+		l.file.Close()
 	}
 }
 

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -34,7 +34,6 @@ func teardown() {
 	os.RemoveAll(config.SDArtifactsDir)
 }
 
-// TODO executor_test should use New
 func TestNew(t *testing.T) {
 	buffer := bytes.NewBuffer([]byte{})
 	dummyFile := &dummyLogFile{buffer: buffer}
@@ -65,7 +64,7 @@ func TestNew(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			lgr, err := New(OutputToFile(tt.file), DebugFlag(tt.debugFlag), OutputDebugLog(tt.hasOutputDebugLog))
+			lgr, err := New(OptOutputToFile(tt.file), OptDebugFlag(tt.debugFlag), OptOutputDebugLog(tt.hasOutputDebugLog))
 
 			assert.Nil(t, err)
 			assert.Equal(t, tt.debugFlag, lgr.debugFlag)
@@ -81,7 +80,7 @@ func TestOutputToFileWithCreate(t *testing.T) {
 	dir := filepath.Join(tempDir, "CreateLogFile")
 	filename := fmt.Sprintf("logger_test_%v", time.Now().Unix())
 
-	lgr, err := New(OutputToFileWithCreate(dir, filename), DebugFlag(log.Ldate))
+	lgr, err := New(OptOutputToFileWithCreate(dir, filename), OptDebugFlag(log.Ldate))
 	defer os.RemoveAll(dir)
 	assert.Nil(t, err)
 	assert.Equal(t, log.Ldate, lgr.debugFlag)
@@ -107,25 +106,25 @@ func TestCanLogFile(t *testing.T) {
 	}{
 		{
 			name:       "OutputToFile: true, OutputDebugLog: false",
-			options:    []LogOption{OutputToFile(d), OutputDebugLog(false), ErrorFlag(0)},
+			options:    []LogOption{OptOutputToFile(d), OptOutputDebugLog(false), OptErrorFlag(0)},
 			logMessage: "Hello",
 			expect:     "Hello\n",
 		},
 		{
 			name:       "OutputToFile: true, OutputDebugLog: true",
-			options:    []LogOption{OutputToFile(d), OutputDebugLog(true), ErrorFlag(0)},
+			options:    []LogOption{OptOutputToFile(d), OptOutputDebugLog(true), OptErrorFlag(0)},
 			logMessage: "Hello",
 			expect:     "Hello\n",
 		},
 		{
 			name:       "OutputToFile: false, OutputDebugLog: false",
-			options:    []LogOption{OutputDebugLog(true), ErrorFlag(0)},
+			options:    []LogOption{OptOutputDebugLog(true), OptErrorFlag(0)},
 			logMessage: "Hello",
 			expect:     "",
 		},
 		{
 			name:       "OutputToFile: false, OutputDebugLog: true",
-			options:    []LogOption{OutputDebugLog(true), ErrorFlag(0)},
+			options:    []LogOption{OptOutputDebugLog(true), OptErrorFlag(0)},
 			logMessage: "Hello",
 			expect:     "",
 		},
@@ -147,25 +146,25 @@ func TestCanLogFile(t *testing.T) {
 	}{
 		{
 			name:       "OutputToFile: true, OutputDebugLog: false",
-			options:    []LogOption{OutputToFile(d), OutputDebugLog(false), DebugFlag(0)},
+			options:    []LogOption{OptOutputToFile(d), OptOutputDebugLog(false), OptDebugFlag(0)},
 			logMessage: "Hello",
 			expect:     "",
 		},
 		{
 			name:       "OutputToFile: true, OutputDebugLog: true",
-			options:    []LogOption{OutputToFile(d), OutputDebugLog(true), DebugFlag(0)},
+			options:    []LogOption{OptOutputToFile(d), OptOutputDebugLog(true), OptDebugFlag(0)},
 			logMessage: "Hello",
 			expect:     "Hello\n",
 		},
 		{
 			name:       "OutputToFile: false, OutputDebugLog: false",
-			options:    []LogOption{OutputDebugLog(true), DebugFlag(0)},
+			options:    []LogOption{OptOutputDebugLog(true), OptDebugFlag(0)},
 			logMessage: "Hello",
 			expect:     "",
 		},
 		{
 			name:       "OutputToFile: false, OutputDebugLog: true",
-			options:    []LogOption{OutputDebugLog(true), DebugFlag(0)},
+			options:    []LogOption{OptOutputDebugLog(true), OptDebugFlag(0)},
 			logMessage: "Hello",
 			expect:     "",
 		},
@@ -189,32 +188,32 @@ func Example_logStderr() {
 	d := &dummyLogFile{buffer: buffer}
 
 	// check Debug debug = false
-	lgr, _ := New(OutputToFile(d), DebugFlag(0), OutputDebugLog(false))
+	lgr, _ := New(OptOutputToFile(d), OptDebugFlag(0), OptOutputDebugLog(false))
 	contents := "Hello this is Debug debug false"
 	lgr.Debug.Println(contents)
 
 	// check Debug debug = true
-	lgr, _ = New(OutputToFile(d), DebugFlag(0), OutputDebugLog(true))
+	lgr, _ = New(OptOutputToFile(d), OptDebugFlag(0), OptOutputDebugLog(true))
 	contents = "Hello this is Debug debug true"
 	lgr.Debug.Println(contents)
 
-	lgr, _ = New(DebugFlag(0), OutputDebugLog(false))
+	lgr, _ = New(OptDebugFlag(0), OptOutputDebugLog(false))
 	contents = "Hello this is Debug debug falase with no file"
 	lgr.Debug.Println(contents)
 
-	lgr, _ = New(DebugFlag(0), OutputDebugLog(true))
+	lgr, _ = New(OptDebugFlag(0), OptOutputDebugLog(true))
 	contents = "Hello this is Debug debug falase with file"
 	lgr.Debug.Println(contents)
 
-	lgr, _ = New(OutputToFile(d), OutputDebugLog(true), ErrorFlag(0))
+	lgr, _ = New(OptOutputToFile(d), OptOutputDebugLog(true), OptErrorFlag(0))
 	contents = "Hello this is Error with file"
 	lgr.Error.Println(contents)
 
-	lgr, _ = New(OutputToFile(d), OutputDebugLog(false), ErrorFlag(0))
+	lgr, _ = New(OptOutputToFile(d), OptOutputDebugLog(false), OptErrorFlag(0))
 	contents = "Hello this is Error with debug false"
 	lgr.Error.Println(contents)
 
-	lgr, _ = New(ErrorFlag(0))
+	lgr, _ = New(OptErrorFlag(0))
 	contents = "Hello this is Error with no file"
 	lgr.Error.Println(contents)
 

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -70,10 +70,18 @@ func TestNew(t *testing.T) {
 			assert.Equal(t, tt.debugFlag, lgr.debugFlag)
 			assert.Equal(t, tt.debugFlag, lgr.Debug.Flags())
 			assert.Equal(t, tt.hasOutputDebugLog, lgr.hasOutputDebugLog)
-			assert.Equal(t, log.LstdFlags, lgr.Error.Flags())
 			assert.Equal(t, tt.file, lgr.file)
 		})
 	}
+
+	t.Run("default value", func(t *testing.T) {
+		lgr, err := New()
+		assert.Nil(t, err)
+		assert.Equal(t, log.LstdFlags, lgr.Error.Flags())
+		assert.Equal(t, log.LstdFlags, lgr.Debug.Flags())
+		assert.Nil(t, lgr.File())
+		assert.False(t, lgr.hasOutputDebugLog)
+	})
 }
 
 func TestOutputToFileWithCreate(t *testing.T) {

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -40,22 +40,22 @@ func TestNew(t *testing.T) {
 	dummyFile := &dummyLogFile{buffer: buffer}
 
 	cases := []struct {
-		name             string
-		debugFlag        int
-		isOutputDebugLog bool
-		file             io.WriteCloser
+		name              string
+		debugFlag         int
+		hasOutputDebugLog bool
+		file              io.WriteCloser
 	}{
 		{
-			name:             "debugFlag: log.Ldate, isOutputDebugLog: true",
-			debugFlag:        log.Ldate,
-			isOutputDebugLog: true,
-			file:             dummyFile,
+			name:              "debugFlag: log.Ldate, isOutputDebugLog: true",
+			debugFlag:         log.Ldate,
+			hasOutputDebugLog: true,
+			file:              dummyFile,
 		},
 		{
-			name:             "debugFlag: 0, isOutputDebugLog: false",
-			debugFlag:        0,
-			isOutputDebugLog: false,
-			file:             dummyFile,
+			name:              "debugFlag: 0, isOutputDebugLog: false",
+			debugFlag:         0,
+			hasOutputDebugLog: false,
+			file:              dummyFile,
 		},
 		{
 			name: "file is nil",
@@ -65,12 +65,12 @@ func TestNew(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			lgr, err := New(OutputToFile(tt.file), DebugFlag(tt.debugFlag), OutputDebugLog(tt.isOutputDebugLog))
+			lgr, err := New(OutputToFile(tt.file), DebugFlag(tt.debugFlag), OutputDebugLog(tt.hasOutputDebugLog))
 
 			assert.Nil(t, err)
 			assert.Equal(t, tt.debugFlag, lgr.debugFlag)
 			assert.Equal(t, tt.debugFlag, lgr.Debug.Flags())
-			assert.Equal(t, tt.isOutputDebugLog, lgr.isOutputDebugLog)
+			assert.Equal(t, tt.hasOutputDebugLog, lgr.hasOutputDebugLog)
 			assert.Equal(t, log.LstdFlags, lgr.Error.Flags())
 			assert.Equal(t, tt.file, lgr.file)
 		})
@@ -85,7 +85,7 @@ func TestOutputToFileWithCreate(t *testing.T) {
 	defer os.RemoveAll(dir)
 	assert.Nil(t, err)
 	assert.Equal(t, log.Ldate, lgr.debugFlag)
-	assert.Equal(t, false, lgr.isOutputDebugLog)
+	assert.Equal(t, false, lgr.hasOutputDebugLog)
 
 	_, err = os.Stat(dir)
 	assert.Nil(t, err)

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -2,14 +2,11 @@ package logger
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
 	"os"
-	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/screwdriver-cd/sd-cmd/config"
 	"github.com/stretchr/testify/assert"
@@ -42,33 +39,18 @@ func newLogger(file io.WriteCloser) (lgr Logger) {
 
 func TestNew(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
-		lgr, err := New()
+		lgr, err := New(nil)
 		assert.Nil(t, lgr.File())
 		assert.Equal(t, log.LstdFlags, lgr.Error.Flags())
 		assert.Equal(t, log.LstdFlags, lgr.Debug.Flags())
 		assert.Nil(t, err)
 	})
 
-	t.Run("OutputToFileWithCreate", func(t *testing.T) {
-		dir := filepath.Join(tempDir, "CreateLogFile")
-		filename := fmt.Sprintf("logger_test_%v", time.Now().Unix())
-
-		lgr, err := New(OptDebugWithCreate(dir, filename))
-		defer os.RemoveAll(dir)
-
-		assert.Nil(t, err)
-		assert.NotNil(t, lgr.File())
-		_, err = os.Stat(dir)
-		assert.Nil(t, err)
-		fileInfos, _ := ioutil.ReadDir(dir)
-		assert.Equal(t, fileInfos[0].Name(), filename)
-	})
-
 	t.Run("OutputToFile", func(t *testing.T) {
 		buffer := bytes.NewBuffer([]byte{})
 		d := &dummyLogFile{buffer: buffer}
 
-		lgr, err := New(OptDebug(d))
+		lgr, err := New(d)
 
 		assert.Nil(t, err)
 		assert.NotNil(t, lgr.File())
@@ -112,6 +94,7 @@ func Example_logStderr() {
 	// Hello this is Error with file
 	// Hello this is Error with no file
 }
+
 func TestMain(m *testing.M) {
 	setup()
 	ret := m.Run()

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -34,7 +34,6 @@ func teardown() {
 	os.RemoveAll(config.SDArtifactsDir)
 }
 
-// TODO be able to set log option with functional option pattern
 // TODO Logger.File to be private
 // TODO CreateLogFile,SetInfo should be private
 // TODO executor_test should use New
@@ -44,17 +43,10 @@ func TestNew(t *testing.T) {
 	filename := fmt.Sprintf("logger_test_%v", time.Now().Unix())
 
 	_, err := New(OutputToFileWithCreate(dir, filename), DebugFlag(log.Ldate), OutputDebugLog())
-	defer os.Remove(filepath.Join(dir, filename))
-	assert.Nil(t, err)
-}
-
-func TestCreateLogFile(t *testing.T) {
-	dir := filepath.Join(tempDir, "CreateLogFile")
-	filename := fmt.Sprintf("logger_test_%v", time.Now().Unix())
 	defer os.RemoveAll(dir)
-	CreateLogFile(dir, filename)
+	assert.Nil(t, err)
 
-	_, err := os.Stat(dir)
+	_, err = os.Stat(dir)
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
 	}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -34,7 +34,6 @@ func teardown() {
 	os.RemoveAll(config.SDArtifactsDir)
 }
 
-// TODO Logger.File to be private
 // TODO CreateLogFile,SetInfo should be private
 // TODO executor_test should use New
 func TestNew(t *testing.T) {
@@ -62,7 +61,7 @@ func TestSetInfos(t *testing.T) {
 	lgr := new(Logger)
 	buffer := bytes.NewBuffer([]byte{})
 	d := &dummyLogFile{buffer: buffer}
-	lgr.SetInfos(d, log.Ldate, false)
+	lgr.setInfos(d, log.Ldate, false)
 
 	if lgr.Debug.Flags() != log.Ldate {
 		t.Errorf("lgr.Debug.Flags=%q, want %q", lgr.Debug.Flags(), log.Ldate)
@@ -78,7 +77,7 @@ func TestCanLogFile(t *testing.T) {
 	d := &dummyLogFile{buffer: buffer}
 
 	// check Error debug = false
-	lgr.SetInfos(d, 0, false)
+	lgr.setInfos(d, 0, false)
 	contents := "Hello this is Error debug false"
 	lgr.Error.Println(contents)
 	if !strings.Contains(d.buffer.String(), contents) {
@@ -87,7 +86,7 @@ func TestCanLogFile(t *testing.T) {
 	d.buffer.Reset()
 
 	// check Error debug = true
-	lgr.SetInfos(d, 0, true)
+	lgr.setInfos(d, 0, true)
 	contents = "Hello this is Error debug true"
 	lgr.Error.Println(contents)
 	if !strings.Contains(d.buffer.String(), contents) {
@@ -96,7 +95,7 @@ func TestCanLogFile(t *testing.T) {
 	d.buffer.Reset()
 
 	// check Debug debug = false
-	lgr.SetInfos(d, 0, false)
+	lgr.setInfos(d, 0, false)
 	contents = "Hello this is Debug debug false"
 	lgr.Debug.Println(contents)
 	if !strings.Contains(d.buffer.String(), contents) {
@@ -105,7 +104,7 @@ func TestCanLogFile(t *testing.T) {
 	d.buffer.Reset()
 
 	// check Debug debug = true
-	lgr.SetInfos(d, 0, true)
+	lgr.setInfos(d, 0, true)
 	contents = "Hello this is Debug debug true"
 	lgr.Debug.Println(contents)
 	if !strings.Contains(d.buffer.String(), contents) {
@@ -123,14 +122,14 @@ func Example_logStderr() {
 	lgr := new(Logger)
 	buffer := bytes.NewBuffer([]byte{})
 	d := &dummyLogFile{buffer: buffer}
-	lgr.SetInfos(d, 0, false)
+	lgr.setInfos(d, 0, false)
 
 	// check Debug debug = false
 	contents := "Hello this is Debug debug false"
 	lgr.Debug.Print(contents)
 
 	// check Debug debug = true
-	lgr.SetInfos(d, 0, true)
+	lgr.setInfos(d, 0, true)
 	contents = "Hello this is Debug debug true"
 	lgr.Debug.Print(contents)
 

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -68,7 +68,6 @@ func TestNew(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, tt.debugFlag, lgr.debugFlag)
 			assert.Equal(t, tt.debugFlag, lgr.Debug.Flags())
-			assert.Equal(t, tt.isDebug, lgr.isDebug)
 		})
 	}
 
@@ -78,7 +77,6 @@ func TestNew(t *testing.T) {
 		assert.Equal(t, log.LstdFlags, lgr.Error.Flags())
 		assert.Equal(t, log.LstdFlags, lgr.Debug.Flags())
 		assert.Nil(t, lgr.File())
-		assert.False(t, lgr.isDebug)
 	})
 }
 
@@ -90,7 +88,7 @@ func TestOutputToFileWithCreate(t *testing.T) {
 	defer os.RemoveAll(dir)
 	assert.Nil(t, err)
 	assert.Equal(t, log.Ldate, lgr.debugFlag)
-	assert.Equal(t, false, lgr.isDebug)
+	assert.NotNil(t, lgr.File())
 
 	_, err = os.Stat(dir)
 	assert.Nil(t, err)

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/screwdriver-cd/sd-cmd/config"
+	"github.com/stretchr/testify/assert"
 )
 
 var tempDir string
@@ -33,15 +34,18 @@ func teardown() {
 	os.RemoveAll(config.SDArtifactsDir)
 }
 
+// TODO be able to set log option with functional option pattern
+// TODO Logger.File to be private
+// TODO CreateLogFile,SetInfo should be private
+// TODO executor_test should use New
 func TestNew(t *testing.T) {
 	// success
 	dir := filepath.Join(tempDir, "CreateLogFile")
 	filename := fmt.Sprintf("logger_test_%v", time.Now().Unix())
-	_, err := New(dir, filename, log.Ldate, false)
+
+	_, err := New(OutputToFileWithCreate(dir, filename), DebugFlag(log.Ldate), OutputDebugLog())
 	defer os.Remove(filepath.Join(dir, filename))
-	if err != nil {
-		t.Errorf("err=%q, want nil", err)
-	}
+	assert.Nil(t, err)
 }
 
 func TestCreateLogFile(t *testing.T) {

--- a/removeTag/removeTag.go
+++ b/removeTag/removeTag.go
@@ -10,9 +10,9 @@ import (
 
 // RemoveTag is a type to remove tags from commands
 type RemoveTag struct {
-	smallSpec     *util.CommandSpec
-	sdAPI         api.API
-	tag           string
+	smallSpec *util.CommandSpec
+	sdAPI     api.API
+	tag       string
 }
 
 // New generates new removeTag.
@@ -39,9 +39,9 @@ func New(api api.API, args []string) (p *RemoveTag, err error) {
 	}
 
 	p = &RemoveTag{
-		smallSpec:     smallSpec,
-		sdAPI:         api,
-		tag:           tag,
+		smallSpec: smallSpec,
+		sdAPI:     api,
+		tag:       tag,
 	}
 
 	return

--- a/removeTag/removeTag_test.go
+++ b/removeTag/removeTag_test.go
@@ -87,8 +87,8 @@ func TestNew(t *testing.T) {
 			Name:      dummyName,
 			Version:   dummyTag,
 		},
-		sdAPI:         sdapi,
-		tag:           dummyTag,
+		sdAPI: sdapi,
+		tag:   dummyTag,
 	}
 	p, err := New(sdapi, []string{dummyCmdName, dummyTag})
 	assert.Nil(t, err)

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -11,7 +11,7 @@ jobs:
         requires: [~commit, ~pr]
         steps:
             - modverify: go mod verify
-            - gofmt: if [[ -n "$(gofmt -l .)" ]]; then echo "gofmt check fails"; gofmt -d .; exit -1; fi
+            - gofmt: /bin/bash -c 'if [[ -n "$(gofmt -l .)" ]]; then echo "gofmt check fails"; gofmt -d .; exit -1; fi'
             - build: GOBIN="$SD_ARTIFACTS_DIR" go install -v ./...
             - test-setup: go get gotest.tools/gotestsum@v0.6.0
             - test: gotestsum --format testname --jsonfile ${SD_ARTIFACTS_DIR}/report.json -- -coverprofile=${SD_ARTIFACTS_DIR}/coverage.out ./...

--- a/sd-cmd.go
+++ b/sd-cmd.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/screwdriver-cd/sd-cmd/config"
 	"github.com/screwdriver-cd/sd-cmd/executor"
-	"github.com/screwdriver-cd/sd-cmd/logger"
 	"github.com/screwdriver-cd/sd-cmd/promoter"
 	"github.com/screwdriver-cd/sd-cmd/publisher"
 	"github.com/screwdriver-cd/sd-cmd/removeTag"
@@ -22,18 +21,12 @@ const (
 	defaultFailureExitCode = 1
 )
 
-func cleanExit() {
-	logger.CloseAll()
-}
-
 func successExit() {
-	cleanExit()
 	os.Exit(0)
 }
 
 // failureExit exits process with 1
 func failureExit(err error) {
-	cleanExit()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
 		if exitError, ok := err.(*exec.ExitError); ok {
@@ -65,6 +58,7 @@ func runExecutor(sdAPI api.API, args []string) (err error) {
 	if err != nil {
 		return
 	}
+	defer executor.CleanUp()
 	err = exec.Run()
 	return
 }

--- a/sd-cmd.go
+++ b/sd-cmd.go
@@ -119,7 +119,7 @@ func runCommand(sdAPI api.API, args []string) error {
 	case "removeTag":
 		return runRemoveTag(sdAPI, args[2:])
 	default:
-		return runExecutor(sdAPI, args)
+		return runExecutor(sdAPI, args[1:])
 	}
 }
 

--- a/sd-cmd.go
+++ b/sd-cmd.go
@@ -109,7 +109,7 @@ func runCommand(sdAPI api.API, args []string) error {
 
 	switch args[1] {
 	case "exec":
-		return runExecutor(sdAPI, args)
+		return runExecutor(sdAPI, args[2:])
 	case "publish":
 		return runPublisher(sdAPI, args[2:])
 	case "promote":

--- a/util/util.go
+++ b/util/util.go
@@ -1,4 +1,4 @@
-  package util
+package util
 
 import (
 	"fmt"


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
I checked how much of the sd-cmd log file is seen, and found that almost all people don't look at the log file.
Users spend time with artifact bookend teardown even if the user does not put files to artifacts because of sd-cmd.
It is better not to create log files to speed up build time.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Not to create log file as default.
- Able to output log files with `--debug` or `-debug` flag.
  - If the debug flag is true, all logs will be written to a file, but error logs will also be output to stderr.
- refactoring surrounded code that  I wrote.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2467

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
