### PR TITLE
[WIP] feat: disable http debug output on non debug mode

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -93,6 +93,8 @@ func New(sdAPI api.API, args []string) (Executor, error) {
 		return nil, err
 	}
 
+	sdAPI.SetDebug(isDebug)
+
 	spec, err := sdAPI.GetCommand(smallSpec)
 	if err != nil {
 		return nil, err

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -108,6 +108,8 @@ func (d *dummySDAPI) RemoveTagCommand(spec *util.CommandSpec, tag string) (*util
 	return nil, nil
 }
 
+func (d *dummySDAPI) SetDebug(isDebug bool) {}
+
 func newDummySDAPI(spec *util.CommandSpec, err error) api.API {
 	d := &dummySDAPI{
 		spec: spec,

--- a/promoter/promoter_test.go
+++ b/promoter/promoter_test.go
@@ -49,6 +49,8 @@ func (d *dummySDAPI) RemoveTagCommand(spec *util.CommandSpec, tag string) (*util
 	return nil, nil
 }
 
+func (d *dummySDAPI) SetDebug(isDebug bool) {}
+
 type dummyInvalidSDAPI struct{}
 
 func (d *dummyInvalidSDAPI) GetCommand(smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
@@ -72,6 +74,8 @@ func (d *dummyInvalidSDAPI) TagCommand(spec *util.CommandSpec, targetVersion, ta
 func (d *dummyInvalidSDAPI) RemoveTagCommand(spec *util.CommandSpec, tag string) (*util.TagResponse, error) {
 	return nil, nil
 }
+
+func (d *dummyInvalidSDAPI) SetDebug(isDebug bool) {}
 
 func TestNew(t *testing.T) {
 	sdapi := api.API(new(dummySDAPI))

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -63,6 +63,8 @@ func (d *dummySDAPI) TagCommand(spec *util.CommandSpec, targetVersion, tag strin
 	}, nil
 }
 
+func (d *dummySDAPI) SetDebug(isDebug bool) {}
+
 func newDummySDAPI(spec *util.CommandSpec, err error) api.API {
 	d := &dummySDAPI{
 		spec: spec,

--- a/removeTag/removeTag_test.go
+++ b/removeTag/removeTag_test.go
@@ -55,6 +55,8 @@ func (d *dummySDAPI) RemoveTagCommand(spec *util.CommandSpec, tag string) (*util
 	}, nil
 }
 
+func (d *dummySDAPI) SetDebug(isDebug bool) {}
+
 type dummyInvalidSDAPI struct{}
 
 func (d *dummyInvalidSDAPI) GetCommand(smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
@@ -76,6 +78,8 @@ func (d *dummyInvalidSDAPI) TagCommand(spec *util.CommandSpec, targetVersion, ta
 func (d *dummyInvalidSDAPI) RemoveTagCommand(spec *util.CommandSpec, tag string) (*util.TagResponse, error) {
 	return nil, errors.New("error")
 }
+
+func (d *dummyInvalidSDAPI) SetDebug(isDebug bool) {}
 
 func TestNew(t *testing.T) {
 	sdapi := api.API(new(dummySDAPI))

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -10,6 +10,7 @@ jobs:
             SD_SONAR_OPTS:  "-Dsonar.sources=./ -Dsonar.exclusions=**/*_test.go,**/vendor/** -Dsonar.tests=./ -Dsonar.test.inclusions=**/*_test.go -Dsonar.test.exclusions=**/vendor/** -Dsonar.go.coverage.reportPaths=${SD_ARTIFACTS_DIR}/coverage.out -Dsonar.go.tests.reportPaths=${SD_ARTIFACTS_DIR}/report.json"
         requires: [~commit, ~pr]
         steps:
+            - gover: go version
             - modverify: go mod verify
             - gofmt: /bin/bash -c 'if [[ -n "$(gofmt -l .)" ]]; then echo "gofmt check fails"; gofmt -d .; exit -1; fi'
             - build: GOBIN="$SD_ARTIFACTS_DIR" go install -v ./...

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -36,6 +36,8 @@ func (d *dummySDAPIValidator) RemoveTagCommand(spec *util.CommandSpec, tag strin
 	return nil, nil
 }
 
+func (d *dummySDAPIValidator) SetDebug(isDebug bool) {}
+
 func TestNew(t *testing.T) {
 	// success
 	testDataPath := "../testdata/yaml/sd-command.yaml"


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When getting a command with sd-cmd, a lot of unnecessary logs for the user can be output.

![20220203 スクリーンショット_2022-02-03_14_46_58](https://user-images.githubusercontent.com/32473622/152289611-1c1ab0f6-1fc9-49f0-8f42-2e26c924aa43.png)

This is noise for users checking the logs.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
sd-cmd already has a flag for debugging and the environment variable SD_CMD_DEBUG_LOG. This function suppresses the log file output. This PR also makes this feature available as a flag for console output suppression.

No configuration:
```
$ ./sd-cmd exec screwdriver-cd-samples/sum@stable 1 2
3
```

flag ON:
```
./sd-cmd exec --debug screwdriver-cd-samples/sum@stable 1 2
2022/02/03 05:51:11 [DEBUG] GET https://***.co.jp/v4/commands/screwdriver-cd-samples/sum/stable
3
```

environment ON:
```
$ SD_CMD_DEBUG_LOG=true ./sd-cmd exec screwdriver-cd-samples/sum@stable 1 2
2022/02/03 05:52:26 [DEBUG] GET https://***.co.jp/v4/commands/screwdriver-cd-samples/sum/stable
3
```

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
