### PR TITLE
feat: Verbose mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ USAGE:
 
 OPTIONS:
    -debug, --debug    Output debug logs to a file
+   -v, --v            Output verbose log to console
 
 EXAMPLE:
    sd-cmd exec foo/bar@stable arg1 arg2

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -26,7 +26,8 @@ var (
 
 // exec subcommand flags
 var (
-	isDebug = false
+	isDebug   = false
+	isVerbose = false
 )
 
 // Executor is a Executor endpoint
@@ -52,6 +53,7 @@ func prepareLog(smallSpec *util.CommandSpec, isDebug bool) (err error) {
 func parseExecSubCommands(args []string) ([]string, error) {
 	f := flag.NewFlagSet("exec", flag.ContinueOnError)
 	f.BoolVar(&isDebug, "debug", false, "output log to file")
+	f.BoolVar(&isVerbose, "v", false, "output verbose log to console")
 	err := f.Parse(args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse exec args: %w", err)
@@ -92,6 +94,8 @@ func New(sdAPI api.API, args []string) (Executor, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	sdAPI.SetVerbose(isVerbose)
 
 	spec, err := sdAPI.GetCommand(smallSpec)
 	if err != nil {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -108,6 +108,8 @@ func (d *dummySDAPI) RemoveTagCommand(spec *util.CommandSpec, tag string) (*util
 	return nil, nil
 }
 
+func (d *dummySDAPI) SetVerbose(isVerbose bool) {}
+
 func newDummySDAPI(spec *util.CommandSpec, err error) api.API {
 	d := &dummySDAPI{
 		spec: spec,

--- a/promoter/promoter_test.go
+++ b/promoter/promoter_test.go
@@ -49,6 +49,8 @@ func (d *dummySDAPI) RemoveTagCommand(spec *util.CommandSpec, tag string) (*util
 	return nil, nil
 }
 
+func (d *dummySDAPI) SetVerbose(isVerbose bool) {}
+
 type dummyInvalidSDAPI struct{}
 
 func (d *dummyInvalidSDAPI) GetCommand(smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
@@ -72,6 +74,8 @@ func (d *dummyInvalidSDAPI) TagCommand(spec *util.CommandSpec, targetVersion, ta
 func (d *dummyInvalidSDAPI) RemoveTagCommand(spec *util.CommandSpec, tag string) (*util.TagResponse, error) {
 	return nil, nil
 }
+
+func (d *dummyInvalidSDAPI) SetVerbose(isVerbose bool) {}
 
 func TestNew(t *testing.T) {
 	sdapi := api.API(new(dummySDAPI))

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -63,6 +63,8 @@ func (d *dummySDAPI) TagCommand(spec *util.CommandSpec, targetVersion, tag strin
 	}, nil
 }
 
+func (d *dummySDAPI) SetVerbose(isVerbose bool) {}
+
 func newDummySDAPI(spec *util.CommandSpec, err error) api.API {
 	d := &dummySDAPI{
 		spec: spec,

--- a/removeTag/removeTag_test.go
+++ b/removeTag/removeTag_test.go
@@ -55,6 +55,8 @@ func (d *dummySDAPI) RemoveTagCommand(spec *util.CommandSpec, tag string) (*util
 	}, nil
 }
 
+func (d *dummySDAPI) SetVerbose(isVerbose bool) {}
+
 type dummyInvalidSDAPI struct{}
 
 func (d *dummyInvalidSDAPI) GetCommand(smallSpec *util.CommandSpec) (*util.CommandSpec, error) {
@@ -76,6 +78,8 @@ func (d *dummyInvalidSDAPI) TagCommand(spec *util.CommandSpec, targetVersion, ta
 func (d *dummyInvalidSDAPI) RemoveTagCommand(spec *util.CommandSpec, tag string) (*util.TagResponse, error) {
 	return nil, errors.New("error")
 }
+
+func (d *dummyInvalidSDAPI) SetVerbose(isVerbose bool) {}
 
 func TestNew(t *testing.T) {
 	sdapi := api.API(new(dummySDAPI))

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -36,6 +36,8 @@ func (d *dummySDAPIValidator) RemoveTagCommand(spec *util.CommandSpec, tag strin
 	return nil, nil
 }
 
+func (d *dummySDAPIValidator) SetVerbose(isVerbose bool) {}
+
 func TestNew(t *testing.T) {
 	// success
 	testDataPath := "../testdata/yaml/sd-command.yaml"


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When getting a command with sd-cmd, a lot of unnecessary logs for the user can be output.

![20220203 スクリーンショット_2022-02-03_14_46_58](https://user-images.githubusercontent.com/32473622/152289611-1c1ab0f6-1fc9-49f0-8f42-2e26c924aa43.png)

This is noise for users checking the logs.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add a new Verbose flag. Console output is suppressed unless this flag is turned ON. The target of suppression is the GET log when the command is acquired.

No flags:
```
$ ./sd-cmd exec screwdriver-cd-samples/sum@stable 1 2
3
```

Flag ON:
```
./sd-cmd exec -v screwdriver-cd-samples/sum@stable 1 2
2022/02/03 06:56:50 [DEBUG] GET https://***.co.jp/v4/commands/screwdriver-cd-samples/sum/stable
3
```

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
