### PR TITLE
fix: Restrict debug store access log by verbose option

### DIFF
--- a/executor/binary.go
+++ b/executor/binary.go
@@ -21,8 +21,10 @@ type Binary struct {
 }
 
 // NewBinary returns Binary object
-func NewBinary(spec *util.CommandSpec, arg []string) (*Binary, error) {
+func NewBinary(spec *util.CommandSpec, arg []string, isVerbose bool) (*Binary, error) {
 	storeapi := store.New(config.SDStoreURL, spec, config.SDToken)
+
+	storeapi.SetVerbose(isVerbose)
 
 	binary := &Binary{
 		Args:  arg,

--- a/executor/binary_test.go
+++ b/executor/binary_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNewBinary(t *testing.T) {
-	_, err := NewBinary(dummyCommandSpec(binaryFormat), []string{"arg1", "arg2"})
+	_, err := NewBinary(dummyCommandSpec(binaryFormat), []string{"arg1", "arg2"}, false)
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
 	}
@@ -20,7 +20,7 @@ func TestNewBinary(t *testing.T) {
 
 func TestGetBinDirPath(t *testing.T) {
 	spec := dummyCommandSpec(binaryFormat)
-	bin, _ := NewBinary(spec, []string{})
+	bin, _ := NewBinary(spec, []string{}, false)
 	bin.Store = newDummyStore(validShell, spec, nil)
 	// Note: config.BaseCommandPath is customized for test.
 	// see executor/executor_test.go
@@ -29,14 +29,14 @@ func TestGetBinDirPath(t *testing.T) {
 
 func TestGetBinFilePath(t *testing.T) {
 	spec := dummyCommandSpec(binaryFormat)
-	bin, _ := NewBinary(spec, []string{})
+	bin, _ := NewBinary(spec, []string{}, false)
 	bin.Store = newDummyStore(validShell, spec, nil)
 	assert.Equal(t, bin.getBinFilePath(), filepath.Join(config.BaseCommandPath, "foo-dummy/name-dummy/1.0.1/sd-step"))
 }
 
 func TestIsInstalled(t *testing.T) {
 	spec := dummyCommandSpec(binaryFormat)
-	bin, _ := NewBinary(spec, []string{})
+	bin, _ := NewBinary(spec, []string{}, false)
 	bin.Store = newDummyStore(validShell, spec, nil)
 	// Not exists
 	assert.False(t, bin.isInstalled())
@@ -59,7 +59,7 @@ func TestRun(t *testing.T) {
 
 	spec := dummyCommandSpec(binaryFormat)
 	// success with no arguments
-	bin, _ := NewBinary(spec, []string{})
+	bin, _ := NewBinary(spec, []string{}, false)
 	bin.Store = newDummyStore(validShell, spec, nil)
 	err := bin.Run()
 	if err != nil {
@@ -80,7 +80,7 @@ func TestRun(t *testing.T) {
 
 	// success binary.file is relative path
 	spec.Binary.File = "./sample/relative_path"
-	bin, _ = NewBinary(spec, []string{})
+	bin, _ = NewBinary(spec, []string{}, false)
 	bin.Store = newDummyStore(validShell, spec, nil)
 	err = bin.Run()
 	if err != nil {
@@ -98,7 +98,7 @@ func TestRun(t *testing.T) {
 	os.Remove(binPath)
 
 	// success with arguments
-	bin, _ = NewBinary(spec, []string{"arg1", "arg2"})
+	bin, _ = NewBinary(spec, []string{"arg1", "arg2"}, false)
 	bin.Store = newDummyStore(validShell, spec, nil)
 	err = bin.Run()
 	if err != nil {
@@ -108,7 +108,7 @@ func TestRun(t *testing.T) {
 	os.Remove(binPath)
 
 	// failure. the command is broken
-	bin, _ = NewBinary(dummyCommandSpec(binaryFormat), []string{})
+	bin, _ = NewBinary(dummyCommandSpec(binaryFormat), []string{}, false)
 	bin.Store = newDummyStore(invalidShell, spec, nil)
 	err = bin.Run()
 	if err == nil {
@@ -117,7 +117,7 @@ func TestRun(t *testing.T) {
 	os.Remove(binPath)
 
 	// failure. the store api return error
-	bin, _ = NewBinary(spec, []string{})
+	bin, _ = NewBinary(spec, []string{}, false)
 	bin.Store = newDummyStore(validShell, spec, fmt.Errorf("store cause error"))
 	err = bin.Run()
 	if err == nil {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -104,9 +104,9 @@ func New(sdAPI api.API, args []string) (Executor, error) {
 
 	switch spec.Format {
 	case "binary":
-		return NewBinary(spec, args[pos+1:])
+		return NewBinary(spec, args[pos+1:], isVerbose)
 	case "habitat":
-		return NewHabitat(spec, args[pos+1:])
+		return NewHabitat(spec, args[pos+1:], isVerbose)
 	case "docker":
 		return nil, errors.New("the docker format is not yet implemented")
 	default:

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -141,6 +141,8 @@ func (d *dummyStore) GetCommand() (*store.Command, error) {
 	return storeCmd, d.err
 }
 
+func (d *dummyStore) SetVerbose(isVerbose bool) {}
+
 func dummyCommandSpec(format string) (spec *util.CommandSpec) {
 	spec = &util.CommandSpec{
 		Namespace:   dummyNameSpace,

--- a/executor/habitat.go
+++ b/executor/habitat.go
@@ -20,8 +20,10 @@ type Habitat struct {
 }
 
 // NewHabitat returns the Habitat struct
-func NewHabitat(spec *util.CommandSpec, args []string) (habitat *Habitat, err error) {
+func NewHabitat(spec *util.CommandSpec, args []string, isVerbose bool) (habitat *Habitat, err error) {
 	storeapi := store.New(config.SDStoreURL, spec, config.SDToken)
+
+	storeapi.SetVerbose(isVerbose)
 
 	habitat = &Habitat{
 		Args:  args,

--- a/executor/habitat_test.go
+++ b/executor/habitat_test.go
@@ -24,7 +24,7 @@ func fakeExecCommand(name string, args ...string) *exec.Cmd {
 }
 
 func TestNewHabitat(t *testing.T) {
-	_, err := NewHabitat(dummyCommandSpec(habitatFormat), dummyArgs)
+	_, err := NewHabitat(dummyCommandSpec(habitatFormat), dummyArgs, false)
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
 	}
@@ -32,7 +32,7 @@ func TestNewHabitat(t *testing.T) {
 
 func TestGetPkgDirPath(t *testing.T) {
 	spec := dummyCommandSpec(habitatFormat)
-	hab, _ := NewHabitat(spec, []string{})
+	hab, _ := NewHabitat(spec, []string{}, false)
 	hab.Store = newDummyStore(validShell, spec, nil)
 	// Note: config.BaseCommandPath is customized for test.
 	// see executor/executor_test.go
@@ -41,14 +41,14 @@ func TestGetPkgDirPath(t *testing.T) {
 
 func TestGetPkgFilePath(t *testing.T) {
 	spec := dummyCommandSpec(habitatFormat)
-	hab, _ := NewHabitat(spec, []string{})
+	hab, _ := NewHabitat(spec, []string{}, false)
 	hab.Store = newDummyStore(validShell, spec, nil)
 	assert.Equal(t, hab.getPkgFilePath(), filepath.Join(config.BaseCommandPath, "foo-dummy/name-dummy/1.0.1/dummy.hart"))
 }
 
 func TestIsDownloaded(t *testing.T) {
 	spec := dummyCommandSpec(habitatFormat)
-	hab, _ := NewHabitat(spec, []string{})
+	hab, _ := NewHabitat(spec, []string{}, false)
 	hab.Store = newDummyStore(validShell, spec, nil)
 	// Not exists
 	assert.False(t, hab.isDownloaded())
@@ -74,7 +74,7 @@ func TestRunHabitat(t *testing.T) {
 	spec := dummyCommandSpec(habitatFormat)
 
 	// case remote mode
-	hab, _ := NewHabitat(spec, dummyArgs)
+	hab, _ := NewHabitat(spec, dummyArgs, false)
 	err := hab.Run()
 	if err != nil {
 		t.Errorf("err=%q, want nil", err)
@@ -83,7 +83,7 @@ func TestRunHabitat(t *testing.T) {
 	// case local mode
 	spec.Habitat.Mode = "local"
 	os.Setenv("HABITAT_MODE", "local")
-	hab, _ = NewHabitat(spec, dummyArgs)
+	hab, _ = NewHabitat(spec, dummyArgs, false)
 	hab.Store = newDummyStore(validShell, spec, nil)
 	err = hab.Run()
 	if err != nil {

--- a/screwdriver/store/store_test.go
+++ b/screwdriver/store/store_test.go
@@ -156,6 +156,46 @@ func TestGetCommand(t *testing.T) {
 	}
 }
 
+func TestGetCommandOnVerbose(t *testing.T) {
+	spec := dummyCommandSpec(binaryFormat)
+	c := newClient(config.SDStoreURL, spec, config.SDToken)
+	store := Store(c)
+	dummyURL := fmt.Sprintf("/v1/commands/%s/%s/%s", dummyNameSpace, dummyName, dummyVersion)
+
+	// Default flag off
+	c.client = makeFakeHTTPClient(t, 200, "Hello World", dummyURL, "text/plain")
+	cmd, err := store.GetCommand()
+	if err != nil {
+		t.Errorf("err=%q, want nil", err)
+	}
+	if cmd.Type != "text/plain" {
+		t.Errorf("cmd.Type=%q, want %q", cmd.Type, "text/plain")
+	}
+	if string(cmd.Body) != "Hello World" {
+		t.Errorf("cmd.Body=%q, want %q", string(cmd.Body), "Hello World")
+	}
+	if c.client.Logger != nil {
+		t.Errorf("Logger=%q, want nil", c.client.Logger)
+	}
+
+	// flag on
+	c.isVerbose = true
+	c.client = makeFakeHTTPClient(t, 200, "Hello World", dummyURL, "text/plain")
+	cmd, err = store.GetCommand()
+	if err != nil {
+		t.Errorf("err=%q, want nil", err)
+	}
+	if cmd.Type != "text/plain" {
+		t.Errorf("cmd.Type=%q, want %q", cmd.Type, "text/plain")
+	}
+	if string(cmd.Body) != "Hello World" {
+		t.Errorf("cmd.Body=%q, want %q", string(cmd.Body), "Hello World")
+	}
+	if c.client.Logger == nil {
+		t.Errorf("Logger=%q, want not nil", c.client.Logger)
+	}
+}
+
 func TestMain(m *testing.M) {
 	setup()
 	ret := m.Run()


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
In #49 , we added the verbose option to restrict debug log.
However, the store access logs still output regardless of the verbose option.
We should also restrict the store access logs.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
The store access logs also suppressed unless this flag is turned ON.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
#49 

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
