### PR TITLE
install binary command atomically

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/screwdriver-cd/sd-cmd/config"
 	"github.com/screwdriver-cd/sd-cmd/logger"
@@ -119,9 +120,10 @@ func newDummySDAPI(spec *util.CommandSpec, err error) api.API {
 }
 
 type dummyStore struct {
-	body []byte
-	spec *util.CommandSpec
-	err  error
+	body            []byte
+	getCommandDelay time.Duration
+	spec            *util.CommandSpec
+	err             error
 }
 
 func newDummyStore(body string, spec *util.CommandSpec, err error) store.Store {
@@ -134,6 +136,9 @@ func newDummyStore(body string, spec *util.CommandSpec, err error) store.Store {
 }
 
 func (d *dummyStore) GetCommand() (*store.Command, error) {
+	if d.getCommandDelay != 0 {
+		time.Sleep(d.getCommandDelay)
+	}
 	storeCmd := &store.Command{
 		Body: d.body,
 		Spec: d.spec,


### PR DESCRIPTION
## Context

fix the `text file busy` problem in parallel execution of the same command.

## Objective

The issue occurred by writing executable during execution. so, I rewrite the logic by creating a temporary file and renaming it.

## References

- fix https://github.com/screwdriver-cd/screwdriver/issues/2090
- Relevant StackOverflow: https://stackoverflow.com/questions/16764946/what-generates-the-text-file-busy-message-in-unix

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
