### PR TITLE
fix: Add cmd info to debug logs

### DIFF
--- a/executor/binary.go
+++ b/executor/binary.go
@@ -117,7 +117,7 @@ func (b *Binary) Run() error {
 
 	binarySpec := b.Spec
 	lgr.Debug.Println("start executing binary command.")
-	lgr.Debug.Println("Namespace:", binarySpec.Namespace, ",Name:", binarySpec.Name, ",version:", binarySpec.Version)
+	lgr.Debug.Println("Namespace:", binarySpec.Namespace, ",Name:", binarySpec.Name, ",Version:", binarySpec.Version)
 	err := execCommand(b.getBinFilePath(), b.Args)
 	if err != nil {
 		lgr.Debug.Println(err)

--- a/executor/binary.go
+++ b/executor/binary.go
@@ -115,7 +115,9 @@ func (b *Binary) Run() error {
 		}
 	}
 
+	binarySpec := b.Spec
 	lgr.Debug.Println("start executing binary command.")
+	lgr.Debug.Println("Namespace:", binarySpec.Namespace, ",Name:", binarySpec.Name, ",version:", binarySpec.Version)
 	err := execCommand(b.getBinFilePath(), b.Args)
 	if err != nil {
 		lgr.Debug.Println(err)

--- a/executor/habitat.go
+++ b/executor/habitat.go
@@ -119,7 +119,9 @@ func (h *Habitat) Run() (err error) {
 		return
 	}
 
+	habitatSpec := h.Spec
 	lgr.Debug.Println("start executing habitat command.")
+	lgr.Debug.Println("Namespace:", habitatSpec.Namespace, ",Name:", habitatSpec.Name, ",Version:", habitatSpec.Version)
 	err = h.exec()
 	if err != nil {
 		lgr.Debug.Println(err)


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently, debug logs only include when cmd is installed, when cmd is executed and how long did it take to execute cmd.
It is useful add info about cmd executed to debug logs.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Output cmd info(namespace, name and version) to debug logs.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
